### PR TITLE
fix: move to ez-ffmpeg to properly encode audio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /target
 /uploads
 /videos

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +354,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -351,6 +398,23 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "ez-ffmpeg"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19050a6a50c4d7ba9bc1bd0d52c47eec56c6c34aa32e84c4cf725f367579856"
+dependencies = [
+ "core-foundation",
+ "crossbeam",
+ "crossbeam-channel",
+ "ffmpeg-next",
+ "ffmpeg-sys-next",
+ "libc",
+ "log",
+ "objc",
+ "thiserror",
 ]
 
 [[package]]
@@ -647,6 +711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +801,15 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -1046,6 +1128,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1351,7 @@ dependencies = [
  "axum",
  "bytes",
  "clap",
+ "ez-ffmpeg",
  "ffmpeg-next",
  "futures",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,13 @@ name = "video-storage"
 version = "0.3.0"
 edition = "2024"
 
+[features]
+debug = []
+
 [dependencies]
 bytes = "1"
-ffmpeg-next = { version = "7.1", features = [
-    "software-resampling",
-    "software-scaling",
-] }
+ffmpeg-next = { version = "7.1.0" }
+ez-ffmpeg = { version = "0.5.3" }
 futures = "0.3"
 mime_guess = "2"
 

--- a/detailed_audio_analysis.sh
+++ b/detailed_audio_analysis.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+
+# Detailed Audio Analysis Script for Video Storage Project
+# This script performs segment-by-segment audio analysis to identify missing audio sections
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}=== Detailed Audio Analysis Tool ===${NC}"
+
+# Check dependencies
+for cmd in ffmpeg ffprobe bc; do
+    if ! command -v "$cmd" &> /dev/null; then
+        echo -e "${RED}Error: $cmd not found. Please install required tools.${NC}"
+        exit 1
+    fi
+done
+
+# Function to analyze audio in segments
+analyze_audio_segments() {
+    local file="$1"
+    local segment_duration="${2:-5}" # Default 5 second segments
+
+    echo -e "\n${YELLOW}=== Segment Analysis for: $file ===${NC}"
+    echo -e "${CYAN}Segment duration: ${segment_duration}s${NC}"
+
+    if [ ! -f "$file" ]; then
+        echo -e "${RED}File not found: $file${NC}"
+        return 1
+    fi
+
+    # Get total duration
+    local total_duration=$(ffprobe -v quiet -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$file" 2>/dev/null || echo "0")
+
+    if (( $(echo "$total_duration <= 0" | bc -l) )); then
+        echo -e "${RED}Could not determine file duration${NC}"
+        return 1
+    fi
+
+    echo -e "${GREEN}Total duration: ${total_duration}s${NC}"
+
+    # Extract complete audio track for analysis
+    local temp_audio="/tmp/detailed_audio_$(basename "$file" .webm).wav"
+    echo -e "${CYAN}Extracting audio to: $temp_audio${NC}"
+
+    ffmpeg -i "$file" -vn -acodec pcm_s16le -ar 44100 -ac 2 "$temp_audio" -y 2>/dev/null || {
+        echo -e "${RED}Failed to extract audio from $file${NC}"
+        return 1
+    }
+
+    # Calculate number of segments
+    local num_segments=$(echo "($total_duration + $segment_duration - 0.01) / $segment_duration" | bc -l | cut -d. -f1)
+
+    echo -e "${GREEN}Analyzing $num_segments segments...${NC}"
+    echo -e "${BLUE}Segment | Start Time | End Time   | RMS Level | Peak Level | Status${NC}"
+    echo -e "${BLUE}--------|-----------|------------|-----------|------------|-------${NC}"
+
+    local silent_segments=0
+    local problematic_segments=()
+
+    for ((i=0; i<num_segments; i++)); do
+        local start_time=$(echo "$i * $segment_duration" | bc -l)
+        local end_time=$(echo "($i + 1) * $segment_duration" | bc -l)
+
+        # Ensure we don't go beyond file duration
+        if (( $(echo "$end_time > $total_duration" | bc -l) )); then
+            end_time=$total_duration
+        fi
+
+        local actual_duration=$(echo "$end_time - $start_time" | bc -l)
+
+        # Skip if segment is too short
+        if (( $(echo "$actual_duration < 0.1" | bc -l) )); then
+            continue
+        fi
+
+        # Analyze this segment
+        local analysis=$(ffmpeg -ss "$start_time" -i "$temp_audio" -t "$actual_duration" -af "volumedetect" -f null - 2>&1 | grep -E "(mean_volume|max_volume)" || echo "mean_volume: N/A dB max_volume: N/A dB")
+
+        local rms_level=$(echo "$analysis" | grep "mean_volume" | awk '{print $5}' || echo "N/A")
+        local peak_level=$(echo "$analysis" | grep "max_volume" | awk '{print $5}' || echo "N/A")
+
+        # Determine status
+        local status="${GREEN}OK${NC}"
+        if [[ "$rms_level" == "N/A" ]] || [[ "$peak_level" == "N/A" ]]; then
+            status="${RED}ERROR${NC}"
+            problematic_segments+=($i)
+        elif (( $(echo "$rms_level == -inf" | bc -l 2>/dev/null || echo "0") )) || [[ "$rms_level" == "-inf" ]]; then
+            status="${YELLOW}SILENT${NC}"
+            silent_segments=$((silent_segments + 1))
+            problematic_segments+=($i)
+        elif (( $(echo "$rms_level < -50" | bc -l 2>/dev/null || echo "0") )); then
+            status="${YELLOW}QUIET${NC}"
+        fi
+
+        printf "%-7s | %-9.2f | %-10.2f | %-9s | %-10s | %s\n" \
+               "$((i+1))" "$start_time" "$end_time" "$rms_level" "$peak_level" "$status"
+    done
+
+    echo -e "\n${YELLOW}=== Analysis Summary ===${NC}"
+    echo -e "${GREEN}Total segments analyzed: $num_segments${NC}"
+    echo -e "${YELLOW}Silent segments: $silent_segments${NC}"
+    echo -e "${RED}Problematic segments: ${#problematic_segments[@]}${NC}"
+
+    if [ ${#problematic_segments[@]} -gt 0 ]; then
+        echo -e "\n${RED}Problematic segment details:${NC}"
+        for seg in "${problematic_segments[@]}"; do
+            local start_time=$(echo "$seg * $segment_duration" | bc -l)
+            local end_time=$(echo "($seg + 1) * $segment_duration" | bc -l)
+            if (( $(echo "$end_time > $total_duration" | bc -l) )); then
+                end_time=$total_duration
+            fi
+            printf "  Segment %d: %.2f - %.2f seconds\n" "$((seg+1))" "$start_time" "$end_time"
+        done
+
+        # Check if problematic segments are at the end
+        local last_segments_check=3
+        local total_segments_to_check=$(echo "$num_segments - $last_segments_check" | bc)
+
+        for seg in "${problematic_segments[@]}"; do
+            if (( $(echo "$seg >= $total_segments_to_check" | bc -l) )); then
+                echo -e "\n${RED}⚠️  AUDIO TRUNCATION DETECTED!${NC}"
+                echo -e "${RED}   Missing audio in the last $last_segments_check segments of the video${NC}"
+                echo -e "${YELLOW}   This confirms the issue: audio ends prematurely${NC}"
+                break
+            fi
+        done
+    fi
+
+    # Additional detailed analysis for last 30 seconds
+    echo -e "\n${CYAN}=== Detailed End-of-File Analysis ===${NC}"
+    local eof_start=$(echo "$total_duration - 30" | bc -l)
+    if (( $(echo "$eof_start < 0" | bc -l) )); then
+        eof_start=0
+    fi
+
+    echo -e "${CYAN}Analyzing last 30 seconds (${eof_start}s - ${total_duration}s) in 1-second intervals:${NC}"
+
+    local end_analysis_segments=$(echo "$total_duration - $eof_start" | bc -l | cut -d. -f1)
+    for ((i=0; i<end_analysis_segments; i++)); do
+        local seg_start=$(echo "$eof_start + $i" | bc -l)
+        local seg_end=$(echo "$eof_start + $i + 1" | bc -l)
+
+        if (( $(echo "$seg_end > $total_duration" | bc -l) )); then
+            seg_end=$total_duration
+        fi
+
+        local seg_analysis=$(ffmpeg -ss "$seg_start" -i "$temp_audio" -t 1 -af "volumedetect" -f null - 2>&1 | grep "mean_volume" | awk '{print $5}' || echo "-inf")
+
+        if [[ "$seg_analysis" == "-inf" ]] || [[ "$seg_analysis" == "N/A" ]]; then
+            printf "  ${RED}%.0f-%.0fs: SILENT${NC}\n" "$seg_start" "$seg_end"
+        else
+            printf "  ${GREEN}%.0f-%.0fs: %s dB${NC}\n" "$seg_start" "$seg_end" "$seg_analysis"
+        fi
+    done
+
+    # Cleanup
+    rm -f "$temp_audio"
+
+    echo -e "\n${BLUE}=== Analysis Complete ===${NC}"
+}
+
+# Function to compare waveforms
+generate_waveform_comparison() {
+    local file="$1"
+    local output_dir="${2:-waveform_analysis}"
+
+    echo -e "\n${YELLOW}=== Generating Waveform Analysis ===${NC}"
+
+    mkdir -p "$output_dir"
+
+    # Generate full waveform
+    local waveform_full="$output_dir/$(basename "$file" .webm)_full_waveform.png"
+    ffmpeg -i "$file" -filter_complex "showwavespic=s=1920x480:colors=blue" -frames:v 1 "$waveform_full" -y 2>/dev/null && {
+        echo -e "${GREEN}Full waveform saved: $waveform_full${NC}"
+    }
+
+    # Generate last 30 seconds waveform
+    local duration=$(ffprobe -v quiet -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$file" 2>/dev/null || echo "0")
+    local start_time=$(echo "$duration - 30" | bc -l)
+    if (( $(echo "$start_time < 0" | bc -l) )); then
+        start_time=0
+    fi
+
+    local waveform_end="$output_dir/$(basename "$file" .webm)_last30s_waveform.png"
+    ffmpeg -ss "$start_time" -i "$file" -t 30 -filter_complex "showwavespic=s=1920x480:colors=red" -frames:v 1 "$waveform_end" -y 2>/dev/null && {
+        echo -e "${GREEN}Last 30s waveform saved: $waveform_end${NC}"
+    }
+}
+
+# Main function
+main() {
+    local input_file=""
+    local segment_duration=5
+    local generate_waveform=false
+    local output_dir="waveform_analysis"
+
+    # Parse command line arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -f|--file)
+                input_file="$2"
+                shift 2
+                ;;
+            -s|--segment-duration)
+                segment_duration="$2"
+                shift 2
+                ;;
+            -w|--waveform)
+                generate_waveform=true
+                shift
+                ;;
+            -o|--output-dir)
+                output_dir="$2"
+                shift 2
+                ;;
+            -h|--help)
+                echo "Usage: $0 [OPTIONS]"
+                echo "Options:"
+                echo "  -f, --file FILE           Video file to analyze"
+                echo "  -s, --segment-duration N  Segment duration in seconds (default: 5)"
+                echo "  -w, --waveform           Generate waveform visualizations"
+                echo "  -o, --output-dir DIR     Output directory for waveforms (default: waveform_analysis)"
+                echo "  -h, --help               Show this help message"
+                echo ""
+                echo "Examples:"
+                echo "  $0 -f video.webm"
+                echo "  $0 -f video.webm -s 10 -w"
+                echo "  $0 -f video.webm -s 1 -w -o analysis_results"
+                exit 0
+                ;;
+            *)
+                echo -e "${RED}Unknown option: $1${NC}"
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "$input_file" ]; then
+        echo -e "${RED}No input file specified. Use -f to specify a file.${NC}"
+        echo "Use --help for usage information"
+        exit 1
+    fi
+
+    # Perform analysis
+    analyze_audio_segments "$input_file" "$segment_duration"
+
+    if [ "$generate_waveform" = true ]; then
+        generate_waveform_comparison "$input_file" "$output_dir"
+    fi
+
+    echo -e "\n${YELLOW}=== Recommendations ===${NC}"
+    echo "1. If silent segments are detected at the end, check the audio flush logic"
+    echo "2. Look for PTS discontinuities in the conversion logs"
+    echo "3. Verify that audio encoder properly handles the last audio frames"
+    echo "4. Check if the audio resampler is dropping samples during flush"
+    echo "5. Consider adding padding to ensure complete audio processing"
+}
+
+main "$@"

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -99,8 +99,10 @@ impl AppState {
                             } else {
                                 info!(%id, ?upload_path, "Upload file removed");
                             };
+
+                            #[cfg(not(feature = "debug"))]
                             let temp_vp9_dir = PathBuf::from(crate::TEMP_DIR).join(format!("tmp-vp9-{id}"));
-                            // let vp9_file = temp_vp9_dir.join("vp9.webm");
+                            #[cfg(not(feature = "debug"))]
                             if let Err(error) = tokio::fs::remove_dir_all(&temp_vp9_dir).await {
                                 error!(%error, %id, ?temp_vp9_dir, "Failed to remove tmp vp9 dir");
                             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,14 @@ const TEMP_DIR: &str = "temp";
 const UPLOADS_DIR: &str = "uploads";
 const VIDEOS_DIR: &str = "videos";
 const VIDEO_OBJECTS_DIR: &str = "video-objects";
+
+#[cfg(feature = "debug")]
+const RESOLUTIONS: [(u32, u32); 1] = [(480, 854)];
+#[cfg(feature = "debug")]
+const BANDWIDTHS: [u32; 1] = [1000000];
+#[cfg(not(feature = "debug"))]
 const RESOLUTIONS: [(u32, u32); 3] = [(720, 1280), (540, 960), (480, 854)];
+#[cfg(not(feature = "debug"))]
 const BANDWIDTHS: [u32; 3] = [2500000, 1500000, 1000000];
 
 #[derive(Parser, Debug)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,33 +2,18 @@ use crate::{BANDWIDTHS, Job, RESOLUTIONS, TEMP_DIR, VIDEOS_DIR};
 
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
+use std::sync::{Arc, Mutex};
 
-use anyhow::{anyhow, bail};
-use ffmpeg_next::format::Pixel::YUV420P;
-use ffmpeg_next::format::Sample;
-use ffmpeg_next::format::context::Output as OutputContext;
-use ffmpeg_next::frame;
-use ffmpeg_next::software::resampling::Context as SamplerContext;
-use ffmpeg_next::software::scaling::context::Context as Scaler;
-use ffmpeg_next::software::scaling::flag::Flags;
-use ffmpeg_next::threading;
-use ffmpeg_next::{ChannelLayout, Rational};
-use ffmpeg_next::{Dictionary, Packet, codec, format, media};
-use tracing::{debug, error, info, trace, warn};
-
-// Opus target parameters
-const OPUS_TARGET_FORMAT: Sample = Sample::F32(format::sample::Type::Packed);
-const OPUS_TARGET_RATE: i32 = 48000; // 48kHz
-const OPUS_TARGET_LAYOUT: ChannelLayout = ChannelLayout::STEREO;
-const OPUS_TARGET_BITRATE: usize = 128_000; // 128kbps
-
-static NUM_CPUS: LazyLock<usize> = LazyLock::new(|| {
-    let n = num_cpus::get();
-    let num = if n > 16 { 16 } else { n };
-    info!(num, "Detecting CPU cores");
-    num
-});
+use anyhow::anyhow;
+use ez_ffmpeg::AVMediaType;
+use ez_ffmpeg::Frame;
+use ez_ffmpeg::container_info::get_duration_us;
+use ez_ffmpeg::filter::frame_filter::FrameFilter;
+use ez_ffmpeg::filter::frame_filter_context::FrameFilterContext;
+use ez_ffmpeg::filter::frame_pipeline_builder::FramePipelineBuilder;
+use ez_ffmpeg::{FfmpegContext, Output};
+use ffmpeg_next::{Dictionary, format, media};
+use tracing::{debug, error, info, warn};
 
 pub(crate) async fn spawn_hls_job(job: Job, upload_path: PathBuf) -> anyhow::Result<()> {
     let temp_dir = PathBuf::from(TEMP_DIR).join(format!("tmp-{}", job.id()));
@@ -54,867 +39,6 @@ pub(crate) async fn spawn_hls_job(job: Job, upload_path: PathBuf) -> anyhow::Res
     Ok(())
 }
 
-// Helper function: checks if a Rational is valid (numerator and denominator are both > 0)
-fn is_rational_valid(r: Rational) -> bool {
-    r.numerator() > 0 && r.denominator() > 0
-}
-
-/// Gets a valid frame rate from the input video stream.
-fn get_valid_frame_rate(in_video_stream: &ffmpeg_next::Stream) -> anyhow::Result<Rational> {
-    // Use avg_frame_rate
-    let avg_fps = in_video_stream.avg_frame_rate();
-    debug!(
-        "Frame Rate Acquisition: Input stream avg_frame_rate: {}/{}",
-        avg_fps.numerator(),
-        avg_fps.denominator()
-    );
-    if is_rational_valid(avg_fps) {
-        debug!("Successfully acquired frame rate using avg_frame_rate.");
-        return Ok(avg_fps);
-    }
-
-    // Use r_frame_rate (in_video_stream.rate())
-    let r_fps = in_video_stream.rate(); // Corresponds to AVStream->r_frame_rate
-    debug!(
-        "Frame Rate Acquisition: Input stream r_frame_rate: {}/{}",
-        r_fps.numerator(),
-        r_fps.denominator()
-    );
-    if is_rational_valid(r_fps) {
-        debug!("Successfully acquired frame rate using r_frame_rate.");
-        return Ok(r_fps);
-    }
-
-    // If both attempts fail
-    let error_message = format!(
-        "Unable to determine a valid frame rate for the encoder. Both sources were invalid.\n\
-         Details:\n\
-         - in_video_stream.avg_frame_rate(): {}/{}\n\
-         - in_video_stream.rate() (r_frame_rate): {}/{}",
-        avg_fps.numerator(),
-        avg_fps.denominator(),
-        r_fps.numerator(),
-        r_fps.denominator()
-    );
-    Err(anyhow!(error_message))
-}
-
-/// Gets a valid encoder timebase according to a prioritized strategy.
-fn get_valid_encoder_timebase(
-    in_video_stream: &ffmpeg_next::Stream,
-    decoder_context: &ffmpeg_next::codec::decoder::Video,
-) -> anyhow::Result<Rational> {
-    // Input stream's time_base (in_video_stream.time_base())
-    let stream_tb = in_video_stream.time_base();
-    debug!(
-        "Timebase Acquisition: Input stream time_base (in_video_stream.time_base()): {}/{}",
-        stream_tb.numerator(),
-        stream_tb.denominator()
-    );
-    if is_rational_valid(stream_tb) {
-        debug!("Successfully acquired: Using in_video_stream.time_base()");
-        return Ok(stream_tb);
-    }
-
-    // From input stream's r_frame_rate (in_video_stream.rate())
-    let r_frame_rate = in_video_stream.rate(); // Corresponds to AVStream->r_frame_rate
-    debug!(
-        "Timebase Acquisition: Input stream r_frame_rate (in_video_stream.rate()): {}/{}",
-        r_frame_rate.numerator(),
-        r_frame_rate.denominator()
-    );
-    if is_rational_valid(r_frame_rate) {
-        // Timebase is the reciprocal of frame rate
-        let derived_tb = Rational::new(r_frame_rate.denominator(), r_frame_rate.numerator());
-        debug!(
-            "Derived time_base from r_frame_rate: {}/{}",
-            derived_tb.numerator(),
-            derived_tb.denominator()
-        );
-        // Re-check derived_tb to ensure no zero in numerator/denominator after inversion
-        if is_rational_valid(derived_tb) {
-            debug!("Successfully acquired: Using time_base derived from r_frame_rate");
-            return Ok(derived_tb);
-        }
-    }
-
-    // From input stream's avg_frame_rate (in_video_stream.avg_frame_rate())
-    let avg_frame_rate = in_video_stream.avg_frame_rate(); // Corresponds to AVStream->avg_frame_rate
-    debug!(
-        "Timebase Acquisition: Input stream avg_frame_rate (in_video_stream.avg_frame_rate()): {}/{}",
-        avg_frame_rate.numerator(),
-        avg_frame_rate.denominator()
-    );
-    if is_rational_valid(avg_frame_rate) {
-        // Timebase is the reciprocal of frame rate
-        let derived_tb = Rational::new(avg_frame_rate.denominator(), avg_frame_rate.numerator());
-        debug!(
-            "Derived time_base from avg_frame_rate: {}/{}",
-            derived_tb.numerator(),
-            derived_tb.denominator()
-        );
-        // Re-check derived_tb
-        if is_rational_valid(derived_tb) {
-            debug!("Successfully acquired: Using time_base derived from avg_frame_rate");
-            return Ok(derived_tb);
-        }
-    }
-
-    // Decoder context's time_base (decoder_context.time_base())
-    let decoder_tb = decoder_context.time_base();
-    debug!(
-        "Timebase Acquisition: Decoder context time_base (decoder_context.time_base()): {}/{}",
-        decoder_tb.numerator(),
-        decoder_tb.denominator()
-    );
-    if is_rational_valid(decoder_tb) {
-        debug!("Successfully acquired: Using decoder_context.time_base()");
-        return Ok(decoder_tb);
-    }
-
-    // If all attempts fail
-    let error_message = format!(
-        "Unable to determine a valid time_base for the encoder. All sources were invalid.\n\
-         Details:\n\
-         - in_video_stream.time_base() (Stream time_base):            {}/{}\n\
-         - in_video_stream.rate() (Stream r_frame_rate):              {}/{}\n\
-         - in_video_stream.avg_frame_rate() (Stream avg_frame_rate):  {}/{}\n\
-         - decoder_context.time_base() (Decoder context time_base): {}/{}",
-        stream_tb.numerator(),
-        stream_tb.denominator(),
-        r_frame_rate.numerator(),
-        r_frame_rate.denominator(),
-        avg_frame_rate.numerator(),
-        avg_frame_rate.denominator(),
-        decoder_tb.numerator(),
-        decoder_tb.denominator()
-    );
-
-    Err(anyhow!(error_message))
-}
-
-#[allow(clippy::field_reassign_with_default)]
-fn setup_vp9_video_encoder(
-    job: &Job,
-    dec_video: &codec::decoder::Video,
-    target_width: u32,
-    target_height: u32,
-    octx: &mut OutputContext,
-    in_video_stream: &ffmpeg_next::Stream,
-) -> anyhow::Result<(usize, codec::encoder::video::Encoder)> {
-    let Job { id: job_id, crf } = &job;
-    debug!(%job_id, target_width, target_height, "Setting up VP9 video encoder...");
-
-    let vp9_codec_finder = codec::encoder::find(codec::Id::VP9)
-        .ok_or_else(|| anyhow!("VP9 Encoder: Codec not found"))?;
-
-    let enc_config_builder = codec::Context::new_with_codec(vp9_codec_finder);
-    let mut enc_config = enc_config_builder
-        .encoder()
-        .video()
-        .map_err(|e| anyhow!("VP9 Encoder: Failed to create config: {e}"))?;
-
-    enc_config.set_flags(codec::Flags::GLOBAL_HEADER);
-
-    let mut threading_config = threading::Config::default();
-    threading_config.count = *NUM_CPUS;
-    threading_config.kind = threading::Type::Slice;
-    enc_config.set_threading(threading_config);
-
-    enc_config.set_format(YUV420P);
-    enc_config.set_width(target_width);
-    enc_config.set_height(target_height);
-
-    let time_base = get_valid_encoder_timebase(in_video_stream, dec_video)?;
-    enc_config.set_time_base(time_base);
-
-    let frame_rate = get_valid_frame_rate(in_video_stream)?;
-    enc_config.set_frame_rate(Some(frame_rate));
-
-    debug!(%job_id, "VP9 Encoder: Timebase set to {}/{}, Frame rate set to {}/{}",
-        time_base.numerator(), time_base.denominator(),
-        frame_rate.numerator(), frame_rate.denominator());
-
-    let mut opts = Dictionary::new();
-    opts.set("crf", &crf.to_string());
-    opts.set("b:v", "0");
-    // VP9 options:
-    // opts.set("row-mt", "1");
-    // opts.set("deadline", "good");
-    // opts.set("cpu-used", "4");
-
-    let tb_before_open = enc_config.time_base();
-    let fr_before_open = enc_config.frame_rate();
-    debug!(%job_id, "VP9 Encoder: Params before open: time_base={}/{}, frame_rate={}/{}",
-        tb_before_open.numerator(), tb_before_open.denominator(),
-        fr_before_open.numerator(), fr_before_open.denominator());
-
-    let opened_encoder = enc_config.open_with(opts).map_err(|e| {
-        anyhow!(
-            "VP9 Encoder: Failed to open: {e}. Input params were TB={}/{}, FR={}/{}.",
-            tb_before_open.numerator(),
-            tb_before_open.denominator(),
-            fr_before_open.numerator(),
-            fr_before_open.denominator()
-        )
-    })?;
-    debug!(%job_id, "VP9 video encoder opened successfully.");
-
-    let mut ost_video = octx.add_stream(vp9_codec_finder.id())?;
-    ost_video.set_parameters(&opened_encoder);
-    debug!(%job_id, "VP9 video stream added to output with index {}", ost_video.index());
-
-    // Explicitly set the stream's own time_base (AVStream->time_base).
-    ost_video.set_time_base(ffmpeg_next::Rational::new(1, 1000));
-
-    Ok((ost_video.index(), opened_encoder))
-}
-
-fn setup_opus_audio_encoder_and_resampler(
-    job_id: &str,
-    dec_audio: &codec::decoder::Audio,
-    octx: &mut OutputContext,
-) -> anyhow::Result<(
-    usize,
-    codec::encoder::audio::Encoder,
-    SamplerContext,
-    usize,
-    usize,
-)> {
-    info!(%job_id, "Setting up Opus audio encoder and resampler..."); // Assuming job_id not passed, use placeholder
-
-    let opus_codec_finder = codec::encoder::find(codec::Id::OPUS).ok_or_else(|| {
-        anyhow!("Opus Encoder: Codec not found (ensure libopus is part of your FFmpeg build)")
-    })?;
-
-    let enc_config_builder = codec::Context::new_with_codec(opus_codec_finder);
-    let mut enc_config = enc_config_builder
-        .encoder()
-        .audio()
-        .map_err(|e| anyhow!("Opus Encoder: Failed to create config: {e}"))?;
-
-    enc_config.set_format(OPUS_TARGET_FORMAT);
-    enc_config.set_rate(OPUS_TARGET_RATE);
-    enc_config.set_channel_layout(OPUS_TARGET_LAYOUT);
-    enc_config.set_bit_rate(OPUS_TARGET_BITRATE);
-    enc_config.set_time_base(Rational::new(1, OPUS_TARGET_RATE)); // Standard for audio
-
-    let opus_opts = Dictionary::new();
-    // opts.set("application", "audio");
-    // opts.set("vbr", "on");
-
-    debug!(%job_id, "Opus Encoder: Params before open: \
-        format={OPUS_TARGET_FORMAT:?}, \
-        rate={OPUS_TARGET_RATE}, \
-        layout={OPUS_TARGET_LAYOUT:?}, \
-        time_base=1/{OPUS_TARGET_RATE}, \
-        bitrate={OPUS_TARGET_BITRATE}"
-    );
-
-    let opened_encoder = enc_config
-        .open_with(opus_opts)
-        .map_err(|e| anyhow!("Opus Encoder: Failed to open: {e}"))?;
-    info!(%job_id, "Opus audio encoder opened successfully.");
-
-    let frame_size = opened_encoder.frame_size();
-    let actual_opus_frame_size = if frame_size == 0 {
-        warn!(%job_id, "Opus encoder reported frame_size 0. Defaulting to 960 (20ms @ 48kHz). This might be risky.");
-        960
-    } else {
-        frame_size as usize
-    };
-    let actual_opus_channels = opened_encoder.channels() as usize;
-    if actual_opus_channels == 0 {
-        bail!("Opus Encoder: Reported 0 channels after opening, cannot proceed.");
-    }
-    debug!(%job_id, "Opus Encoder: Reported frame_size: {actual_opus_frame_size}, channels: {actual_opus_channels}");
-
-    let mut ost_audio = octx.add_stream(opus_codec_finder.id())?;
-    ost_audio.set_parameters(&opened_encoder);
-    debug!(%job_id, "Opus audio stream added to output with index {}", ost_audio.index());
-
-    // Explicitly set the stream's own time_base (AVStream->time_base)
-    ost_audio.set_time_base(Rational::new(1, OPUS_TARGET_RATE)); // Assuming OPUS_TARGET_RATE is u32 or similar, cast to i32
-
-    debug!(%job_id, "Opus audio stream (index {}) added. Stream time_base: {:?}",
-        ost_audio.index(),
-        ost_audio.time_base(), // Verify this is now 1/OPUS_TARGET_RATE
-    );
-
-    // --- Audio Resampler Setup ---
-    let in_ch_layout = dec_audio.channel_layout();
-    let mut in_ch_layout_valid = if in_ch_layout.is_empty() || in_ch_layout.channels() == 0 {
-        debug!(%job_id, "Audio Resampler: Input audio channel layout is empty/invalid, using default for {} channels.", dec_audio.channels());
-        ChannelLayout::default(dec_audio.channels().into())
-    } else {
-        in_ch_layout
-    };
-    if in_ch_layout_valid.channels() != dec_audio.channels() as i32 && dec_audio.channels() > 0 {
-        warn!(%job_id, "Audio Resampler: \
-            Channel layout ({in_ch_layout_valid:?}, {}ch) channel count mismatch \
-            with decoder channel count ({}ch). Adjusting layout.",
-            in_ch_layout_valid.channels(),
-            dec_audio.channels()
-        );
-        in_ch_layout_valid = ChannelLayout::default(dec_audio.channels().into());
-    }
-
-    debug!(%job_id, "Audio Resampler: Input Config: format={:?}, rate={}, layout={in_ch_layout_valid:?} ({} channels from decoder)",
-        dec_audio.format(), dec_audio.rate(), dec_audio.channels());
-    debug!(%job_id, "Audio Resampler: Output Config: format={OPUS_TARGET_FORMAT:?}, rate={OPUS_TARGET_RATE}, layout={OPUS_TARGET_LAYOUT:?}");
-
-    let resampler = SamplerContext::get(
-        dec_audio.format(),
-        in_ch_layout_valid,
-        dec_audio.rate(),
-        OPUS_TARGET_FORMAT,
-        OPUS_TARGET_LAYOUT,
-        OPUS_TARGET_RATE as u32,
-    )
-    .map_err(|e| anyhow!("Audio Resampler: Failed to create: {e}"))?;
-    debug!(%job_id, "Audio resampler created.");
-
-    Ok((
-        ost_audio.index(),
-        opened_encoder,
-        resampler,
-        actual_opus_frame_size,
-        actual_opus_channels,
-    ))
-}
-
-/// Handles an encoded video packet by rescaling its timestamps and writing it to the output context.
-fn handle_encoded_video_packet(
-    job_id: &str,
-    encoded_packet: &mut Packet,
-    output_stream_index: usize,
-    encoder_output_time_base: Rational,
-    output_format_context: &mut format::context::Output,
-) -> anyhow::Result<()> {
-    // Log the state of the packet as it comes from the encoder
-    let original_pts_val = encoded_packet.pts();
-    let original_dts_val = encoded_packet.dts();
-    let original_duration_val = encoded_packet.duration();
-
-    trace!(
-        %job_id,
-        PTS_raw = ?original_pts_val,
-        DTS_raw = ?original_dts_val,
-        Duration_raw = ?original_duration_val,
-        Encoder_Output_TB = ?encoder_output_time_base,
-        "Video packet FROM ENCODER"
-    );
-
-    // Set the stream index for the packet
-    encoded_packet.set_stream(output_stream_index);
-
-    // Get the target time_base from the output stream context
-    let target_stream_time_base = output_format_context
-        .stream(output_stream_index)
-        .ok_or_else(|| {
-            let message = format!("Failed to get output stream for index {output_stream_index}");
-            error!(%job_id, %message);
-            anyhow!(message)
-        })?
-        .time_base();
-
-    // Ensure both source (encoder_output_time_base) and target time_bases are valid for rescaling
-    if encoder_output_time_base.denominator() == 0 {
-        let message = format!(
-            "Source (encoder output) time_base {encoder_output_time_base:?} has a zero denominator, cannot rescale PTS."
-        );
-        error!(%job_id, %message);
-        return Err(anyhow!(message));
-    }
-    if target_stream_time_base.denominator() == 0 {
-        // This check should ideally be redundant if prior setup guarantees a valid target_stream_time_base (like 1/1000)
-        let message = format!(
-            "Target (output stream) time_base {target_stream_time_base:?} has a zero denominator, cannot rescale PTS."
-        );
-        error!(%job_id, %message);
-        return Err(anyhow!(message));
-    }
-
-    trace!(%job_id, ?encoder_output_time_base, ?target_stream_time_base, "Video RESCALE_TS");
-
-    // Perform the timestamp rescaling
-    encoded_packet.rescale_ts(encoder_output_time_base, target_stream_time_base);
-
-    // Log the state of the packet after rescaling
-    let final_pts_val = encoded_packet.pts();
-    let final_dts_val = encoded_packet.dts();
-    let final_duration_val = encoded_packet.duration();
-
-    trace!(
-        %job_id,
-        PTS_final = ?final_pts_val,
-        DTS_final = ?final_dts_val,
-        Duration_final = ?final_duration_val,
-        Target_Stream_TB = ?target_stream_time_base,
-        "Video packet AFTER RESCALE_TS",
-    );
-
-    // Log PTS in seconds for easier interpretation
-    if let Some(pts) = final_pts_val {
-        // Check denominator again just for this calculation, as rescale_ts might produce strange rationals if inputs were weird
-        if target_stream_time_base.denominator() != 0 {
-            let pts_in_seconds = pts as f64 * target_stream_time_base.numerator() as f64
-                / target_stream_time_base.denominator() as f64;
-            trace!(%job_id, "Video packet AFTER RESCALE_TS: PTS_final_seconds={pts_in_seconds:.3}s");
-        } else if target_stream_time_base.numerator() == 0
-            && target_stream_time_base.denominator() == 1
-        {
-            // Handle case like Rational(0,1) which is valid but results in 0 seconds.
-            trace!(%job_id, "Video packet AFTER RESCALE_TS: PTS_final_seconds=0.000s (Target_Stream_TB is 0/1)");
-        } else {
-            // This case should have been caught by the denominator check above before rescale_ts.
-            warn!(
-                %job_id,
-                "Cannot calculate PTS in seconds for logging because Target_Stream_TB denominator is zero (was {target_stream_time_base:?})."
-            );
-        }
-    }
-
-    // Write the packet to the output file
-    if let Err(e) = encoded_packet.write_interleaved(output_format_context) {
-        let message = format!("Output: Error writing interleaved video packet: {e}");
-        error!(%job_id, %message);
-        return Err(anyhow!(message));
-    }
-
-    Ok(())
-}
-
-/// Handles an encoded audio packet: sets metadata, logs, and writes to output.
-fn handle_encoded_audio_packet(
-    job_id: &str,
-    encoded_packet: &mut Packet,
-    output_stream_index: usize,
-    current_pts_in_source_tb: i64,     // audio_next_pts
-    packet_duration_in_source_tb: i64, // opus_frame_size
-    output_format_context: &mut OutputContext,
-) -> anyhow::Result<()> {
-    encoded_packet.set_stream(output_stream_index);
-
-    encoded_packet.set_pts(Some(current_pts_in_source_tb));
-    encoded_packet.set_dts(Some(current_pts_in_source_tb));
-    encoded_packet.set_duration(packet_duration_in_source_tb);
-
-    let source_audio_time_base = Rational::new(1, OPUS_TARGET_RATE);
-    let target_webm_audio_time_base = Rational::new(1, 1000);
-
-    trace!(
-        %job_id,
-        Raw_PTS = current_pts_in_source_tb,
-        Raw_Duration = packet_duration_in_source_tb,
-        Source_TB = ?source_audio_time_base,
-        Source_TB = ?source_audio_time_base,
-        Target_TB = ?target_webm_audio_time_base,
-        "Audio packet BEFORE RESCALE",
-    );
-
-    encoded_packet.rescale_ts(source_audio_time_base, target_webm_audio_time_base);
-
-    let final_pts = encoded_packet.pts().unwrap_or(0);
-    let final_duration = encoded_packet.duration();
-    let pts_in_seconds = if target_webm_audio_time_base.denominator() != 0 {
-        final_pts as f64 * target_webm_audio_time_base.numerator() as f64
-            / target_webm_audio_time_base.denominator() as f64
-    } else {
-        0.0
-    };
-
-    trace!(
-        %job_id,
-        "Audio packet AFTER RESCALE (PREPARED for writing): Final_PTS={}, Final_Duration={}, PTS_seconds={:.3}s, Target_TB={:?}",
-        final_pts,
-        final_duration,
-        pts_in_seconds,
-        target_webm_audio_time_base
-    );
-
-    // 5. 写入数据包
-    if let Err(e) = encoded_packet.write_interleaved(output_format_context) {
-        let error = format!(
-            "Output: Error writing interleaved audio packet (Rescaled PTS {final_pts}): {e}",
-        );
-        error!(%job_id, %error);
-        return Err(anyhow!(error));
-    }
-
-    Ok(())
-}
-
-fn flush_video_path(
-    job_id: &str,
-    dec_video: &mut codec::decoder::Video,
-    scaler: &mut Scaler,
-    enc_video: &mut codec::encoder::Video,
-    octx: &mut OutputContext,
-    in_video_time_base: Rational,
-    out_video_stream_idx: usize,
-) -> anyhow::Result<()> {
-    debug!(%job_id, "Flushing video decoder and encoder...");
-
-    // Drain the decoder
-    debug!(%job_id, "Sending EOF to video decoder...");
-    dec_video.send_eof()?;
-    let mut decoded_video_frame_eof = frame::Video::empty();
-    let mut scaled_video_frame_eof = frame::Video::empty();
-    loop {
-        match dec_video.receive_frame(&mut decoded_video_frame_eof) {
-            Ok(_) => {
-                // Frame successfully received from decoder
-                match scaler.run(&decoded_video_frame_eof, &mut scaled_video_frame_eof) {
-                    Ok(_) => {
-                        scaled_video_frame_eof.set_pts(decoded_video_frame_eof.pts());
-                        if let Err(e) = enc_video.send_frame(&scaled_video_frame_eof) {
-                            // EAGAIN might happen if encoder needs draining, but we drain below anyway.
-                            // Log other errors.
-                            if e != (ffmpeg_next::Error::Other {
-                                errno: ffmpeg_next::util::error::EAGAIN,
-                            }) {
-                                warn!(%job_id, "VP9 Encoder: Error sending flushed frame: {e}, skipping.");
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        warn!(%job_id, "Video Scaler: Error during flush: {e}, skipping frame.")
-                    }
-                }
-                // Try draining the encoder immediately after sending a frame
-                // This loop structure assumes linear draining. Complex interactions might need different logic.
-                let mut encoded_video_packet = Packet::empty();
-                while enc_video.receive_packet(&mut encoded_video_packet).is_ok() {
-                    encoded_video_packet.set_stream(out_video_stream_idx);
-                    encoded_video_packet.rescale_ts(
-                        in_video_time_base,
-                        octx.stream(out_video_stream_idx).unwrap().time_base(),
-                    );
-                    if encoded_video_packet.write_interleaved(octx).is_err() {
-                        error!(%job_id, "Output: Error writing flushed interleaved video packet, stopping.");
-                        return Err(anyhow!(
-                            "Output: Error writing flushed interleaved video packet"
-                        ));
-                    }
-                }
-                // Ignore EAGAIN from receive_packet here, continue draining decoder
-            }
-            Err(ffmpeg_next::Error::Eof) => {
-                // <-- CORRECT EOF Check
-                debug!(%job_id, "Video decoder fully flushed (EOF received).");
-                break; // Exit the decoder drain loop
-            }
-            Err(e) => {
-                // Handle other real errors
-                error!(%job_id, "Video Decoder: Error receiving flushed frame: {}", e);
-                return Err(e.into());
-            }
-        }
-    } // End decoder drain loop
-
-    // Send EOF to the encoder and drain it completely
-    debug!(%job_id, "Sending EOF to video encoder...");
-    enc_video.send_eof()?;
-    let mut encoded_video_packet_eof = Packet::empty();
-    loop {
-        match enc_video.receive_packet(&mut encoded_video_packet_eof) {
-            Ok(_) => {
-                if let Err(error) = handle_encoded_video_packet(
-                    job_id,
-                    &mut encoded_video_packet_eof,
-                    out_video_stream_idx,
-                    in_video_time_base, // Use the passed encoder's output time_base
-                    octx,
-                ) {
-                    // Log error, but might continue flushing other packets unless it's a fatal write error
-                    error!(%job_id, ?error, "Error handling flushed video packet");
-                    // Decide if to propagate or just log
-                }
-            }
-            Err(ffmpeg_next::Error::Eof) => {
-                // <-- CORRECT EOF Check
-                debug!(%job_id, "Video encoder fully flushed (EOF received).");
-                break; // Exit the encoder drain loop
-            }
-            Err(error) => {
-                // Handle other real errors
-                error!(%job_id, ?error, "VP9 Encoder: Error receiving final packet");
-                return Err(error.into());
-            }
-        }
-    } // End encoder drain loop
-
-    debug!(%job_id, "Video path flushed successfully.");
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-fn flush_audio_path(
-    job_id: &str,
-    dec_audio: &mut codec::decoder::Audio,
-    audio_resampler: &mut SamplerContext,
-    enc_audio: &mut codec::encoder::Audio,
-    octx: &mut OutputContext,
-    out_audio_stream_idx: usize,
-    audio_sample_buffer: &mut Vec<f32>,
-    opus_input_frame: &mut frame::Audio,
-    opus_frame_size: usize,
-    opus_num_channels: usize,
-    audio_next_pts: &mut i64,
-) -> anyhow::Result<()> {
-    debug!(
-        %job_id,
-        "Flushing audio path starting. Initial audio_next_pts: {} ({:.3}s)",
-        *audio_next_pts, *audio_next_pts as f64 / OPUS_TARGET_RATE as f64
-    );
-
-    // 1. Drain the audio decoder
-    debug!(%job_id, "Sending EOF to audio decoder...");
-    dec_audio.send_eof()?;
-    let mut decoded_audio_frame_eof = frame::Audio::empty();
-    loop {
-        match dec_audio.receive_frame(&mut decoded_audio_frame_eof) {
-            Ok(_) => {
-                // Frame received
-                let mut temp_resampled_frame_eof = frame::Audio::empty();
-                if audio_resampler
-                    .run(&decoded_audio_frame_eof, &mut temp_resampled_frame_eof)
-                    .is_ok()
-                    && temp_resampled_frame_eof.samples() > 0
-                {
-                    // Append data to buffer
-                    let num_new_samples = temp_resampled_frame_eof.samples();
-                    let samples_ptr = temp_resampled_frame_eof.data(0).as_ptr() as *const f32;
-                    let new_data_slice = unsafe {
-                        std::slice::from_raw_parts(samples_ptr, num_new_samples * opus_num_channels)
-                    };
-                    audio_sample_buffer.extend_from_slice(new_data_slice);
-                }
-            }
-            Err(ffmpeg_next::Error::Eof) => {
-                // <-- CORRECT EOF Check
-                debug!(%job_id, "Audio decoder fully flushed (EOF received).");
-                break; // Exit decoder drain loop
-            }
-            Err(e) => {
-                error!(%job_id, "Audio Decoder: Error receiving flushed frame: {}", e);
-                return Err(e.into());
-            }
-        }
-    } // End decoder drain loop
-
-    // 2. Flush the resampler (Simplified version - see previous notes)
-    // ... (resampler flush logic remains the same conceptually) ...
-    debug!(%job_id, "Attempting to flush audio resampler (simplified method)...");
-    let mut flushed_samples = true;
-    let empty_input_for_flush =
-        frame::Audio::new(dec_audio.format(), 0, dec_audio.channel_layout());
-    while flushed_samples {
-        let mut temp_resampled_frame_eof = frame::Audio::empty();
-        if audio_resampler
-            .run(&empty_input_for_flush, &mut temp_resampled_frame_eof)
-            .is_ok()
-            && temp_resampled_frame_eof.samples() > 0
-        {
-            let num_new_samples = temp_resampled_frame_eof.samples();
-            let samples_ptr = temp_resampled_frame_eof.data(0).as_ptr() as *const f32;
-            let new_data_slice = unsafe {
-                std::slice::from_raw_parts(samples_ptr, num_new_samples * opus_num_channels)
-            };
-            audio_sample_buffer.extend_from_slice(new_data_slice);
-            flushed_samples = true;
-        } else {
-            flushed_samples = false;
-        }
-    }
-    debug!(%job_id, "Audio resampler flushing attempted. Buffer size for final processing: {} samples per channel", audio_sample_buffer.len() / opus_num_channels);
-
-    // 3. Process all full frames remaining in the buffer
-    while audio_sample_buffer.len() >= opus_frame_size * opus_num_channels {
-        // ... (copy data to opus_input_frame) ...
-        let samples_for_opus_frame_len = opus_frame_size * opus_num_channels;
-        let plane_data_mut = opus_input_frame.data_mut(0);
-        unsafe {
-            let dest_ptr = plane_data_mut.as_mut_ptr() as *mut f32;
-            let src_ptr = audio_sample_buffer.as_ptr();
-            std::ptr::copy_nonoverlapping(src_ptr, dest_ptr, samples_for_opus_frame_len);
-        }
-        audio_sample_buffer.drain(0..samples_for_opus_frame_len);
-        opus_input_frame.set_pts(None);
-
-        if let Err(e) = enc_audio.send_frame(opus_input_frame) {
-            /* handle error */
-            return Err(anyhow!(
-                "Failed sending buffered audio frame during flush: {e}",
-            ));
-        }
-
-        let mut encoded_audio_packet = Packet::empty();
-        // Inner drain loop for encoder after sending one frame
-        loop {
-            match enc_audio.receive_packet(&mut encoded_audio_packet) {
-                Ok(_) => {
-                    handle_encoded_audio_packet(
-                        job_id,
-                        &mut encoded_audio_packet,
-                        out_audio_stream_idx,
-                        *audio_next_pts,
-                        opus_frame_size as i64,
-                        octx,
-                    )?;
-                    *audio_next_pts += opus_frame_size as i64;
-                }
-                Err(ffmpeg_next::Error::Other { errno })
-                    if errno == ffmpeg_next::util::error::EAGAIN =>
-                {
-                    // Encoder needs more input or is finishing this frame batch. Break inner loop.
-                    break;
-                }
-                Err(ffmpeg_next::Error::Eof) => {
-                    // This shouldn't happen here as we haven't sent EOF to encoder yet. Log warning/error.
-                    warn!(%job_id, "Opus Encoder: Received EOF unexpectedly while draining buffer.");
-                    break; // Treat as end for this inner loop
-                }
-                Err(e) => {
-                    /* handle other errors */
-                    return Err(anyhow!(
-                        "Opus Encoder: Error receiving packet while draining buffer: {}",
-                        e
-                    ));
-                }
-            }
-        } // End inner encoder drain loop
-    } // End while buffer has full frames
-
-    // 4. Handle the very last partial frame
-    if !audio_sample_buffer.is_empty() {
-        // ... (padding logic remains the same conceptually) ...
-        let remaining_sample_count_per_channel = audio_sample_buffer.len() / opus_num_channels;
-        debug!(%job_id, "Processing final {} audio samples per channel by padding.", remaining_sample_count_per_channel);
-        let total_f32s_in_opus_frame = opus_frame_size * opus_num_channels;
-        let mut final_frame_samples: Vec<f32> = Vec::with_capacity(total_f32s_in_opus_frame);
-        final_frame_samples.extend_from_slice(audio_sample_buffer);
-        let padding_needed_f32s = total_f32s_in_opus_frame - final_frame_samples.len();
-        if padding_needed_f32s > 0 {
-            final_frame_samples.resize(total_f32s_in_opus_frame, 0.0f32);
-        }
-
-        let plane_data_mut = opus_input_frame.data_mut(0);
-        if plane_data_mut.len() < final_frame_samples.len() * std::mem::size_of::<f32>() {
-            return Err(anyhow!(
-                "Opus input frame buffer allocation mismatch during final padding"
-            ));
-        }
-
-        debug!(%job_id, "Performing unsafe copy of final padded samples to frame plane...");
-        unsafe {
-            /* copy data */
-            std::ptr::copy_nonoverlapping(
-                final_frame_samples.as_ptr(),
-                plane_data_mut.as_mut_ptr() as *mut f32,
-                total_f32s_in_opus_frame,
-            );
-        }
-        debug!(%job_id, "Unsafe copy for final frame completed.");
-        opus_input_frame.set_pts(None);
-
-        if let Err(e) = enc_audio.send_frame(opus_input_frame) {
-            /* handle error */
-            return Err(anyhow!("Failed sending final audio frame: {}", e));
-        }
-
-        // Drain the encoder after sending final frame
-        let mut encoded_audio_packet = Packet::empty();
-        loop {
-            // Use loop with match for draining
-            match enc_audio.receive_packet(&mut encoded_audio_packet) {
-                Ok(_) => {
-                    handle_encoded_audio_packet(
-                        job_id,
-                        &mut encoded_audio_packet,
-                        out_audio_stream_idx,
-                        *audio_next_pts,
-                        opus_frame_size as i64,
-                        octx,
-                    )?;
-                    *audio_next_pts += opus_frame_size as i64;
-                }
-                Err(ffmpeg_next::Error::Other { errno })
-                    if errno == ffmpeg_next::util::error::EAGAIN =>
-                {
-                    // Expected when draining after sending one frame might not yield packet immediately
-                    break;
-                }
-                Err(ffmpeg_next::Error::Eof) => {
-                    warn!(%job_id, "Opus Encoder: Received EOF unexpectedly while draining final padded frame.");
-                    break;
-                }
-                Err(e) => {
-                    return Err(anyhow!(
-                        "Opus Encoder: Error receiving packet after final padded frame: {e}"
-                    ));
-                }
-            }
-        } // End drain after final padded frame
-    }
-    // Clear buffer regardless
-    audio_sample_buffer.clear();
-
-    // 5. Send EOF to the audio encoder and drain it completely
-    debug!(%job_id, "Sending EOF to Opus audio encoder...");
-    enc_audio.send_eof()?;
-    let mut encoded_audio_packet_eof = Packet::empty();
-    let mut encoder_final_drain_packets = 0;
-    loop {
-        match enc_audio.receive_packet(&mut encoded_audio_packet_eof) {
-            Ok(_) => {
-                encoder_final_drain_packets += 1;
-                let packet_duration = if encoded_audio_packet_eof.duration() > 0 {
-                    encoded_audio_packet_eof.duration()
-                } else {
-                    opus_frame_size as i64
-                };
-                handle_encoded_audio_packet(
-                    job_id,
-                    &mut encoded_audio_packet_eof,
-                    out_audio_stream_idx,
-                    *audio_next_pts,
-                    packet_duration, // Use determined packet_duration
-                    octx,
-                )?;
-
-                trace!(
-                    %job_id,
-                    "Audio packet from Step 5 (encoder EOF drain, packet #{}): audio_next_pts={}, PTS_seconds={:.3}s, packet_duration_used={}",
-                    encoder_final_drain_packets,
-                    *audio_next_pts,
-                    *audio_next_pts as f64 / OPUS_TARGET_RATE as f64,
-                    packet_duration
-                );
-                *audio_next_pts += packet_duration;
-            }
-            Err(ffmpeg_next::Error::Eof) => {
-                // <-- CORRECT EOF Check
-                debug!(%job_id, "Opus audio encoder fully flushed (EOF received).");
-                break; // Exit encoder drain loop
-            }
-            Err(e) => {
-                // Handle other real errors
-                error!(%job_id, "Opus Encoder: Error receiving final packet: {}", e);
-                return Err(e.into());
-            }
-        }
-    } // End encoder EOF drain loop
-
-    debug!(
-        %job_id,
-        "Audio path flushed successfully. Final audio_next_pts value after all processing: {} ({:.3}s).",
-        *audio_next_pts, *audio_next_pts as f64 / OPUS_TARGET_RATE as f64
-    );
-    Ok(())
-}
-
 /// Convert MP4 to a VP9 variant of a specific height.
 pub fn convert_to_vp9_variant(
     job: &Job,
@@ -922,277 +46,69 @@ pub fn convert_to_vp9_variant(
     output: &Path,
     target_width: u32,
     target_height: u32,
+    frame_pipeline: FramePipelineBuilder,
 ) -> anyhow::Result<()> {
     let Job { id: job_id, crf } = job;
     debug!(%job_id, %crf, ?input, ?output, "Converting to {target_width}P VP9 variant");
 
-    let mut ictx = format::input(input.to_str().unwrap())
-        .map_err(|e| anyhow!("Failed to open input video: {e}"))?;
-    let mut octx = format::output_as(output.to_str().unwrap(), "webm")
-        .map_err(|e| anyhow!("Failed to create ouput context: {e}"))?;
-
-    let in_video = ictx
-        .streams()
-        .best(media::Type::Video)
-        .ok_or_else(|| anyhow!("Can not find input video stream"))?;
-    let in_audio = ictx
-        .streams()
-        .best(media::Type::Audio)
-        .ok_or_else(|| anyhow!("Can not find input audio stream"))?;
-    let in_video_idx = in_video.index();
-    let in_audio_idx = in_audio.index();
-
-    let codec_params = in_video.parameters();
-    let codec = codec::context::Context::from_parameters(codec_params)?;
-    let mut dec_video = codec.decoder().video()?;
-
-    let codec_params = in_audio.parameters();
-    let codec = codec::context::Context::from_parameters(codec_params)?;
-    let mut dec_audio = codec.decoder().audio()?;
-
-    let original_width = dec_video.width();
-    let original_height = dec_video.height();
-
-    let mut scaler = Scaler::get(
-        dec_video.format(),
-        original_width,
-        original_height,
-        YUV420P,
-        target_width,
-        target_height,
-        Flags::BILINEAR,
-    )?;
-
-    // Setup video encoder
-    let (out_video_stream_idx, mut enc_video) = setup_vp9_video_encoder(
-        job,
-        &dec_video,
-        target_width,
-        target_height,
-        &mut octx,
-        &in_video,
-    )?;
-
-    // Setup audio encoder and resampler
-    let (
-        out_audio_stream_idx,
-        mut enc_audio,
-        mut audio_resampler,
-        opus_frame_size,
-        opus_num_channels,
-    ) = setup_opus_audio_encoder_and_resampler(job_id, &dec_audio, &mut octx)?;
-
-    debug!(
-        "Output audio stream time_base before write_header: {:?}",
-        octx.stream(out_audio_stream_idx).unwrap().time_base()
-    );
-    debug!(
-        "Output video stream time_base before write_header: {:?}",
-        octx.stream(out_video_stream_idx).unwrap().time_base()
-    );
-
-    octx.write_header()
-        .map_err(|e| anyhow!("Output: Failed to write context header: {e}"))?;
-    debug!("Output context header written successfully.");
-
-    let in_video_time_base = in_video.time_base();
-    let mut decoded_video_frame = frame::Video::empty();
-    let mut scaled_video_frame = frame::Video::empty();
-    let mut decoded_audio_frame = frame::Audio::empty();
-    let mut audio_sample_buffer: Vec<f32> = Vec::new();
-    let mut opus_input_frame =
-        frame::Audio::new(OPUS_TARGET_FORMAT, opus_frame_size, OPUS_TARGET_LAYOUT);
-
-    info!(%job_id, "Starting packet processing loop. Opus frame size: {}, Opus channels: {}", opus_frame_size, opus_num_channels);
-
-    // Initialize PTS counter for audio
-    let mut audio_next_pts: i64 = 0;
-    let total_duration_us = ictx.duration();
-    let mut last_reported_progress_video_ts_us: i64 = 0;
-    const PROGRESS_INTERVAL_US: i64 = 10_000_000; // 10 seconds in microseconds
-
-    'main_loop: for (stream, packet) in ictx.packets() {
-        if stream.index() == in_video_idx {
-            // ... (video processing logic as in your last full code) ...
-            if dec_video.send_packet(&packet).is_err() {
-                warn!(%job_id, "Video Decoder: Error sending packet, skipping.");
-                continue;
-            }
-            while dec_video.receive_frame(&mut decoded_video_frame).is_ok() {
-                if let Some(pts) = decoded_video_frame.pts() {
-                    // Convert current frame's PTS to microseconds
-                    let current_video_ts_us =
-                        (pts * in_video_time_base.numerator() as i64 * 1_000_000)
-                            / in_video_time_base.denominator() as i64;
-
-                    if current_video_ts_us
-                        >= last_reported_progress_video_ts_us + PROGRESS_INTERVAL_US
-                    {
-                        if total_duration_us > 0 {
-                            let percent = (current_video_ts_us as f64 / total_duration_us as f64
-                                * 100.0)
-                                .min(100.0);
-                            let current_s = current_video_ts_us as f64 / 1_000_000.0;
-                            let total_s = total_duration_us as f64 / 1_000_000.0;
-                            info!(
-                                %job_id, target_width, target_height,
-                                "Conversion Progress: {:.1}% ({:.1}s / {:.1}s processed)",
-                                percent, current_s, total_s
-                            );
-                        } else {
-                            // Total duration unknown, just print current time processed
-                            let current_s = current_video_ts_us as f64 / 1_000_000.0;
-                            info!(%job_id, "Conversion Progress: {:.1}s processed", current_s);
-                        }
-                        // Update last_reported_progress_video_ts_us to the boundary that was just crossed
-                        last_reported_progress_video_ts_us =
-                            (current_video_ts_us / PROGRESS_INTERVAL_US) * PROGRESS_INTERVAL_US;
-                    }
-                }
-
-                if scaler
-                    .run(&decoded_video_frame, &mut scaled_video_frame)
-                    .is_err()
-                {
-                    warn!(%job_id, "Video Scaler: Error, skipping frame.");
-                    continue;
-                }
-                scaled_video_frame.set_pts(decoded_video_frame.pts());
-                if enc_video.send_frame(&scaled_video_frame).is_err() {
-                    warn!(%job_id, "VP9 Encoder: Error sending frame, skipping.");
-                    continue;
-                }
-                let mut encoded_video_packet = Packet::empty();
-                while enc_video.receive_packet(&mut encoded_video_packet).is_ok() {
-                    if let Err(error) = handle_encoded_video_packet(
-                        job_id,
-                        &mut encoded_video_packet,
-                        out_video_stream_idx,
-                        in_video_time_base,
-                        &mut octx,
-                    ) {
-                        error!(%job_id, ?error, "Failed to handle encoded video packet, Stopping.");
-                        // Consider breaking the main loop or handling the error appropriately
-                        break 'main_loop; // Make sure 'main_loop is the correct label for your outer loop
-                    }
-                }
-            }
-        } else if stream.index() == in_audio_idx {
-            if dec_audio.send_packet(&packet).is_err() {
-                warn!(%job_id, "Audio Decoder: Error sending packet, skipping.");
-                continue;
-            }
-            while dec_audio.receive_frame(&mut decoded_audio_frame).is_ok() {
-                let mut temp_resampled_frame = frame::Audio::empty();
-                match audio_resampler.run(&decoded_audio_frame, &mut temp_resampled_frame) {
-                    Ok(_) => {
-                        if temp_resampled_frame.samples() > 0 {
-                            let num_new_samples = temp_resampled_frame.samples();
-                            let samples_ptr = temp_resampled_frame.data(0).as_ptr() as *const f32;
-                            let new_data_slice = unsafe {
-                                std::slice::from_raw_parts(
-                                    samples_ptr,
-                                    num_new_samples * opus_num_channels,
-                                )
-                            };
-                            audio_sample_buffer.extend_from_slice(new_data_slice);
-                        }
-                    }
-                    Err(e) => {
-                        warn!(%job_id, "Audio Resampler: Error during run: {e}, skipping this audio data.");
-                        continue;
-                    }
-                }
-                while audio_sample_buffer.len() >= opus_frame_size * opus_num_channels {
-                    let samples_for_opus_frame_len = opus_frame_size * opus_num_channels;
-                    let plane_data_mut = opus_input_frame.data_mut(0);
-                    unsafe {
-                        let dest_ptr = plane_data_mut.as_mut_ptr() as *mut f32;
-                        let src_ptr = audio_sample_buffer.as_ptr();
-                        std::ptr::copy_nonoverlapping(
-                            src_ptr,
-                            dest_ptr,
-                            samples_for_opus_frame_len,
-                        );
-                    }
-                    audio_sample_buffer.drain(0..samples_for_opus_frame_len);
-                    opus_input_frame.set_pts(None);
-                    if enc_audio.send_frame(&opus_input_frame).is_err() {
-                        warn!(%job_id, "Opus Encoder: Error sending frame, data might be lost.");
-                        break;
-                    }
-                    let mut encoded_audio_packet = Packet::empty();
-                    while enc_audio.receive_packet(&mut encoded_audio_packet).is_ok() {
-                        if let Err(error) = handle_encoded_audio_packet(
-                            job_id,
-                            &mut encoded_audio_packet,
-                            out_audio_stream_idx,
-                            audio_next_pts, // Pass the current value of audio_next_pts
-                            opus_frame_size as i64, // Standard duration for Opus frames
-                            &mut octx,
-                        ) {
-                            error!(%job_id, ?error, "Output: Error writing interleaved audio packet, stopping.");
-                            break 'main_loop;
-                        };
-                        audio_next_pts += opus_frame_size as i64; // Increment PTS for the next packet
-                    }
-                }
-            }
-        }
-    }
-    // Final progress log
-    if total_duration_us > 0 {
-        let total_s_final = total_duration_us as f64 / 1_000_000.0;
-        info!(%job_id, "Conversion Progress: 100.0% ({:.1}s / {:.1}s processed) (finalizing)", total_s_final, total_s_final);
-    }
-
-    debug!(%job_id, "Flushing remaining frames...");
-    flush_video_path(
-        job_id,
-        &mut dec_video,
-        &mut scaler,
-        &mut enc_video,
-        &mut octx,
-        in_video_time_base,
-        out_video_stream_idx,
-    )?;
-    flush_audio_path(
-        job_id,
-        &mut dec_audio,
-        &mut audio_resampler,
-        &mut enc_audio,
-        &mut octx,
-        out_audio_stream_idx,
-        &mut audio_sample_buffer,
-        &mut opus_input_frame,
-        opus_frame_size,
-        opus_num_channels,
-        &mut audio_next_pts,
-    )?;
-
-    octx.write_trailer()
-        .map_err(|e| anyhow!("Output: Failed to write trailer: {e}"))?;
-    info!(%job_id, ?output, "Conversion to WebM (VP9/Opus) completed successfully.");
-
-    Ok(())
+    let output = Output::from(output.to_str().unwrap())
+        .set_video_codec_opt("crf", crf.to_string())
+        .add_frame_pipeline(frame_pipeline);
+    Ok(FfmpegContext::builder()
+        .input(input.to_str().unwrap())
+        .filter_desc(format!("scale={target_width}:{target_height}"))
+        .output(output)
+        .build()?
+        .start()?
+        .wait()?)
 }
 
-pub(crate) fn create_master_playlist(
-    job: &Job,
-    input: &Path,
-    out_dir: &Path,
-) -> anyhow::Result<()> {
+pub(crate) fn create_master_playlist(job: &Job, input: &Path, output: &Path) -> anyhow::Result<()> {
     let job_id = job.id();
-    let temp_vp9_dir = PathBuf::from(TEMP_DIR).join(format!("tmp-vp9-{job_id}"));
-    std::fs::create_dir_all(&temp_vp9_dir)?;
+    let vp9 = PathBuf::from(TEMP_DIR).join(format!("tmp-vp9-{job_id}"));
+    std::fs::create_dir_all(&vp9)?;
 
-    for (width, height) in RESOLUTIONS {
-        // Convert to target height VP9 variant
-        convert_to_target_hls(job, input, &temp_vp9_dir, width, height, out_dir)
-            .inspect_err(|error| error!(%error, "Failed to convert to {width}x{height}P HLS"))?;
+    let input_str = input.to_str().unwrap();
+    let total = get_duration_us(input_str).unwrap();
+    info!(%job_id, "Duration: {} us", total);
+
+    let mut progress_callbacker = ProgressCallBacker::new(job_id.to_string());
+    progress_callbacker.total_duration = total;
+
+    // Retrieve the audio stream information
+    let audio_info = ez_ffmpeg::stream_info::find_audio_stream_info(input_str).unwrap();
+    if let Some(audio_info) = audio_info {
+        if let ez_ffmpeg::stream_info::StreamInfo::Audio { time_base, .. } = audio_info {
+            progress_callbacker.time_base = time_base;
+            info!(%job_id, "Audio time base: {}/{}", time_base.num, time_base.den);
+        }
+    } else {
+        warn!("Audio stream information not found");
     }
 
-    let master_playlist_path = out_dir.join(format!("{job_id}.m3u8"));
+    let with_filters = RESOLUTIONS
+        .iter()
+        .map(|&(w, h)| {
+            let frame_pipeline: FramePipelineBuilder = AVMediaType::AVMEDIA_TYPE_AUDIO.into();
+            let progress_filter = ProgressCallBackFilter::new(w, progress_callbacker.dup());
+            let pipe = frame_pipeline.filter("progress", Box::new(progress_filter));
+            (w, h, pipe)
+        })
+        .collect::<Vec<_>>();
+
+    use rayon::prelude::*;
+    // use rayon::iter::ParallelIterator as _;
+    with_filters
+        .into_par_iter()
+        .map(|(width, height, pipe)| {
+            let job_c = job.clone();
+            convert_to_target_hls(&job_c, input, &vp9, width, height, output, pipe).inspect_err(
+                |error| error!(%error, "Failed to convert to {}x{}P HLS", width, height),
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let master_playlist_path = output.join(format!("{job_id}.m3u8"));
     let mut file = std::fs::File::create(&master_playlist_path)?;
 
     let mut content = String::new();
@@ -1228,6 +144,7 @@ pub(crate) fn convert_to_target_hls(
     target_width: u32,
     target_height: u32,
     out_dir: &Path,
+    frame_pipeline: FramePipelineBuilder,
 ) -> anyhow::Result<()> {
     let job_id = job.id();
     let vp9_file = temp_dir.join(format!("{target_width}P.webm"));
@@ -1235,8 +152,15 @@ pub(crate) fn convert_to_target_hls(
     std::fs::create_dir_all(&out_dir)?;
 
     // convert to vp9
-    convert_to_vp9_variant(job, input, &vp9_file, target_width, target_height)
-        .inspect_err(|error| error!(%error, "Failed to convert to {target_width}P vp9"))?;
+    convert_to_vp9_variant(
+        job,
+        input,
+        &vp9_file,
+        target_width,
+        target_height,
+        frame_pipeline,
+    )
+    .inspect_err(|error| error!(%error, "Failed to convert to {target_width}P vp9"))?;
     let input = vp9_file;
     let input_path = input.to_str().ok_or(anyhow!("Empty input path"))?;
 
@@ -1300,4 +224,94 @@ pub(crate) fn convert_to_target_hls(
     }
     octx.write_trailer()?;
     Ok(())
+}
+
+pub struct ProgressCallBacker {
+    job_id: String,
+    total_duration: i64,
+    time_base: ez_ffmpeg::AVRational,
+    last_report: Arc<Mutex<i64>>,
+}
+
+impl ProgressCallBacker {
+    pub fn new(job_id: String) -> Self {
+        Self {
+            job_id,
+            total_duration: 0,
+            time_base: ez_ffmpeg::AVRational { num: 0, den: 0 },
+            last_report: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    pub fn dup(&self) -> Self {
+        Self {
+            job_id: self.job_id.clone(),
+            total_duration: self.total_duration,
+            time_base: self.time_base,
+            last_report: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    pub fn print_progress(&self, width: u32, frame: &Frame) {
+        if let Some(pts) = frame.pts() {
+            // Check if the time base is valid.
+            if self.time_base.den == 0 {
+                warn!("The time base denominator is 0, and the time cannot be calculated.");
+                return;
+            }
+
+            let mut last_reported = self.last_report.lock().unwrap();
+            // Get the timestamp of the frame (in seconds).
+            let time = pts * self.time_base.num as i64 * 100 / self.time_base.den as i64;
+            let total = self.total_duration / 10_000;
+
+            if time >= *last_reported + 1_000 {
+                *last_reported = time;
+                let time = time as f64 / 100.0;
+                let total = total as f64 / 100.0;
+                let progress = (time / total) * 100.0;
+                let clamped = progress.clamp(0.0, 100.0);
+                info!(
+                    job_id = %self.job_id,
+                    width,
+                    "Progress: {clamped:.2}% (Current: {time:.3}s / Total: {total:.2}s, PTS: {pts})"
+                );
+            }
+        }
+    }
+}
+
+pub struct ProgressCallBackFilter {
+    width: u32,
+    progress_callback: ProgressCallBacker,
+}
+
+impl ProgressCallBackFilter {
+    pub fn new(width: u32, progress_callback: ProgressCallBacker) -> Self {
+        Self {
+            width,
+            progress_callback,
+        }
+    }
+}
+
+impl FrameFilter for ProgressCallBackFilter {
+    fn media_type(&self) -> AVMediaType {
+        AVMediaType::AVMEDIA_TYPE_AUDIO // Process audio frames
+    }
+
+    fn filter_frame(
+        &mut self,
+        frame: Frame,
+        _ctx: &FrameFilterContext,
+    ) -> Result<Option<Frame>, String> {
+        unsafe {
+            // Ensure the frame is valid and not empty
+            if frame.as_ptr().is_null() || frame.is_empty() {
+                return Ok(Some(frame)); // If invalid, simply return the frame as-is
+            }
+        }
+        self.progress_callback.print_progress(self.width, &frame);
+        Ok(Some(frame))
+    }
 }


### PR DESCRIPTION
Originally used ffmpeg-next for audio resampling, but it frequently dropped the last few seconds of audio. Have temporarily switched to ez-ffmpeg.

ez-ffmpeg is simpler and more intuitive, but its abstraction is too high-level, which prevents the reuse of decoded input data when processing multiple resolutions. If that bug can be resolved later, the preference is to switch back to using the low-level API.