### PR TITLE
feat: add no auth video serving in internal endpoint

### DIFF
--- a/crates/core/src/api/middleware.rs
+++ b/crates/core/src/api/middleware.rs
@@ -1,5 +1,6 @@
 use axum::{body::Body, http::Request, middleware::Next, response::Response};
 use tracing::{error, warn};
+use video_storage_claim::ClaimBucket;
 
 pub async fn log_request_errors(req: Request<Body>, next: Next) -> Response {
     let uri = req.uri().clone();
@@ -26,4 +27,15 @@ pub async fn log_request_errors(req: Request<Body>, next: Next) -> Response {
     }
 
     response
+}
+
+/// Middleware for claim-based authentication and authorization
+pub async fn no_auth_middleware(mut req: Request<Body>, next: Next) -> Response {
+    let bucket = ClaimBucket::new(0.0, 0, 0, 0);
+
+    // Store bucket in extensions for the route handler to use
+    req.extensions_mut().insert(bucket);
+
+    // Continue to the actual handler
+    next.run(req).await
 }

--- a/crates/core/src/api/mod.rs
+++ b/crates/core/src/api/mod.rs
@@ -2,5 +2,5 @@ pub mod middleware;
 pub mod routes;
 
 // Re-export public types and functions
-pub use middleware::log_request_errors;
+pub use middleware::{log_request_errors, no_auth_middleware};
 pub use routes::{create_claim, serve_video, upload_mp4_raw, waitlist};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -114,7 +114,9 @@ pub async fn run(config: Config) {
         .route("/claims", post(create_claim))
         .route("/upload", post(upload_mp4_raw))
         .route("/waitlist", get(waitlist))
+        .route("/videos/{*filename}", get(serve_video))
         .layer(axum::middleware::from_fn(api::log_request_errors))
+        .layer(axum::middleware::from_fn(api::no_auth_middleware))
         .layer(cors)
         .layer(Extension(state));
 


### PR DESCRIPTION
Added a video acquisition interface that does not require authentication on the internal endpoint