### PR TITLE
feat: removed fixed s3 bucket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,8 @@ jobs:
               run: |
                   dnf install -y git epel-release
                   dnf config-manager --set-enabled crb
-                  dnf install -y gcc gcc-c++ make cmake pkgconfig
+                  # rockylinux:9 ships curl-minimal by default; installing curl can conflict.
+                  dnf install -y gcc gcc-c++ make cmake pkgconfig ca-certificates
 
             # Install Rust
             - name: Install Rust
@@ -161,6 +162,61 @@ jobs:
             # Tests
             - name: Run tests with nextest
               run: make test
+
+            - name: Run S3 integration tests (MinIO)
+              run: |
+                  set -euo pipefail
+
+                  endpoint=http://127.0.0.1:9000
+
+                  # Install MinIO client (mc)
+                  mc_bin=/tmp/mc
+                  curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o "$mc_bin"
+                  chmod +x "$mc_bin"
+
+                  # Install MinIO server
+                  arch="$(uname -m)"
+                  case "$arch" in
+                      x86_64|amd64) minio_arch=amd64 ;;
+                      aarch64|arm64) minio_arch=arm64 ;;
+                      *) echo "unsupported arch: $arch" >&2; exit 1 ;;
+                  esac
+                  minio_bin=/tmp/minio
+                  curl -fsSL "https://dl.min.io/server/minio/release/linux-${minio_arch}/minio" -o "$minio_bin"
+                  chmod +x "$minio_bin"
+
+                  data_dir="$(mktemp -d /tmp/vs-minio-data.XXXXXX)"
+                  export MINIO_ROOT_USER=minioadmin
+                  export MINIO_ROOT_PASSWORD=minioadmin
+                  export MINIO_BROWSER=off
+                  "$minio_bin" server "$data_dir" --address 127.0.0.1:9000 >/tmp/vs-minio.log 2>&1 &
+                  minio_pid=$!
+                  trap 'kill "$minio_pid" >/dev/null 2>&1 || true; rm -rf "$data_dir" || true' EXIT
+
+                  # Wait for MinIO to be ready
+                  for i in {1..60}; do
+                      if curl -fsS "$endpoint/minio/health/ready" >/dev/null; then
+                          break
+                      fi
+                      sleep 1
+                  done
+                  if ! curl -fsS "$endpoint/minio/health/ready" >/dev/null; then
+                      echo "MinIO not ready" >&2
+                      tail -n 200 /tmp/vs-minio.log >&2 || true
+                      exit 1
+                  fi
+
+                  "$mc_bin" alias set vsminio "$endpoint" minioadmin minioadmin
+                  "$mc_bin" mb -p vsminio/vs-test-src
+                  "$mc_bin" mb -p vsminio/vs-test-dst
+
+                  VS_TEST_S3_ENDPOINT="$endpoint" \
+                  VS_TEST_S3_REGION=us-east-1 \
+                  VS_TEST_S3_ACCESS_KEY_ID=minioadmin \
+                  VS_TEST_S3_SECRET_ACCESS_KEY=minioadmin \
+                  VS_TEST_S3_SRC_BUCKET=vs-test-src \
+                  VS_TEST_S3_DST_BUCKET=vs-test-dst \
+                  cargo test -p video-storage-core --test s3_optional_integration_test -- --ignored
 
             # Verify binary
             - name: Verify binary

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ video-storage -p 1 \
 When `storage_backend = "s3"`, the bucket is selected per request/job:
 - Upload/convert: pass `dst_bucket` in the `/upload` query string (e.g. `/upload?...&dst_bucket=my-bucket`)
 - Playback: request via `/videos/<bucket>/<key>` (e.g. `/videos/my-bucket/720/<job_id>.m3u8`)
+- Migrate between buckets (internal API): `POST /migrate {src_bucket, dst_bucket, job_id, ...}`
 - Note: `dst_bucket` must not be numeric-only (e.g. `123`).
 
 ### Using configuration file
@@ -242,7 +243,7 @@ Returns JSON with pending job counts.
 example:
 
 ```shell
-curl -X GET http://127.0.0.1:32145/waitlist
+curl -X GET http://127.0.0.1:32146/waitlist
 ```
 
 response:
@@ -258,7 +259,9 @@ response:
 ## Upload video
 
 ```shell
-curl -X POST "http://0.0.0.0:32145/upload?id=video&crf=48" --data-binary @video.mp4 -H "Content-Type: application/octet-stream"
+curl -X POST "http://127.0.0.1:32146/upload?id=video&crf=48" \
+  --data-binary @video.mp4 \
+  -H "Content-Type: application/octet-stream"
 ```
 
 - id: not contain ' ', '-', '/', '.' and not exist
@@ -267,7 +270,8 @@ curl -X POST "http://0.0.0.0:32145/upload?id=video&crf=48" --data-binary @video.
 ## Get resource
 
 ```shell
-http://127.0.0.1:32145/videos/video.m3u8
+curl -H "Authorization: Bearer YOUR_CLAIM_TOKEN" \
+  http://127.0.0.1:32145/videos/my-bucket/video.m3u8
 ```
 
 ## Authentication and Authorization
@@ -320,12 +324,12 @@ Parameters:
 Include the claim token in the Authorization header:
 
 ```shell
-curl -X GET http://127.0.0.1:32145/videos/1920/video123.m3u8 \
+curl -X GET http://127.0.0.1:32145/videos/my-bucket/480/video123.m3u8 \
   -H "Authorization: Bearer YOUR_CLAIM_TOKEN"
 ```
 
 The service will validate:
 1. The token is valid and not expired
 2. The requested asset matches the claim's asset_id
-3. The requested width (1920 in this example) is in the allowed_widths list
+3. The requested width (480 in this example) is in the allowed_widths list
 4. The request is within bandwidth and concurrency limits

--- a/README.md
+++ b/README.md
@@ -131,8 +131,6 @@ Options:
           Configuration file path (overrides all other arguments)
   -s, --storage-backend <STORAGE_BACKEND>
           Storage backend: local or s3 [default: local]
-      --s3-bucket <S3_BUCKET>
-          S3 bucket name (required when storage-backend is s3)
       --s3-endpoint <S3_ENDPOINT>
           S3 endpoint (for MinIO/custom S3)
       --s3-region <S3_REGION>
@@ -172,13 +170,17 @@ cargo build --release
 ```shell
 video-storage -p 1 \
   -s s3 \
-  --s3-bucket video-storage \
   --s3-endpoint http://127.0.0.1:9000 \
   --s3-region us-east-1 \
   --s3-access-key-id minioadmin \
   --s3-secret-access-key minioadmin \
   --webhook-url https://example.com/webhook
 ```
+
+When `storage_backend = "s3"`, the bucket is selected per request/job:
+- Upload/convert: pass `dst_bucket` in the `/upload` query string (e.g. `/upload?...&dst_bucket=my-bucket`)
+- Playback: request via `/videos/<bucket>/<key>` (e.g. `/videos/my-bucket/720/<job_id>.m3u8`)
+- Note: `dst_bucket` must not be numeric-only (e.g. `123`).
 
 ### Using configuration file
 
@@ -209,7 +211,6 @@ workspace = "./data"
 storage_backend = "s3"  # Options: "local" or "s3"
 
 # S3 configuration (required when storage_backend = "s3")
-s3_bucket = "video-storage"
 s3_endpoint = "http://127.0.0.1:9000"
 s3_region = "us-east-1"
 s3_access_key_id = "minioadmin"

--- a/config.example.toml
+++ b/config.example.toml
@@ -13,7 +13,6 @@ storage_backend = "local"         # Storage backend: "local" or "s3"
 
 # S3 configuration (only required when storage_backend = "s3")
 # Uncomment and configure the following lines for S3/MinIO storage
-# s3_bucket = "video-storage"             # S3 bucket name
 # s3_endpoint = "http://localhost:9000"   # S3 endpoint (for MinIO or custom S3)
 # s3_region = "us-east-1"                 # AWS region
 # s3_access_key_id = "minioadmin"         # S3 access key ID
@@ -54,7 +53,6 @@ storage_backend = "local"         # Storage backend: "local" or "s3"
 # token_rate = 0.0
 # workspace = "./data"
 # storage_backend = "s3"
-# s3_bucket = "video-storage"
 # s3_endpoint = "http://localhost:9000"
 # s3_region = "us-east-1"
 # s3_access_key_id = "minioadmin"
@@ -69,7 +67,6 @@ storage_backend = "local"         # Storage backend: "local" or "s3"
 # token_rate = 0.0
 # workspace = "./data"
 # storage_backend = "s3"
-# s3_bucket = "my-video-bucket"
 # s3_region = "us-west-2"
 # s3_access_key_id = "AKIAIOSFODNN7EXAMPLE"
 # s3_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
@@ -83,7 +80,6 @@ storage_backend = "local"         # Storage backend: "local" or "s3"
 # token_rate = 100.0
 # workspace = "/var/lib/video-storage"
 # storage_backend = "s3"
-# s3_bucket = "production-videos"
 # s3_region = "us-east-1"
 # s3_access_key_id = "AKIAIOSFODNN7EXAMPLE"
 # s3_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
@@ -93,7 +89,6 @@ storage_backend = "local"         # Storage backend: "local" or "s3"
 
 # === Environment Variables ===
 # You can also use environment variables for sensitive data:
-# - S3_BUCKET
 # - S3_ENDPOINT
 # - AWS_REGION
 # - AWS_ACCESS_KEY_ID

--- a/config.example.toml
+++ b/config.example.toml
@@ -18,6 +18,10 @@ storage_backend = "local"         # Storage backend: "local" or "s3"
 # s3_access_key_id = "minioadmin"         # S3 access key ID
 # s3_secret_access_key = "minioadmin"     # S3 secret access key
 
+# Note (S3 mode):
+# - Bucket is selected per request/job (e.g. /upload?...&dst_bucket=... and /videos/<bucket>/<key>)
+# - Internal migration endpoint is available: POST /migrate {src_bucket, dst_bucket, job_id, ...}
+
 # Webhook configuration (optional)
 # Uncomment to enable webhook notifications when jobs complete
 # webhook_url = "https://example.com/webhook"  # Webhook endpoint URL

--- a/crates/claim/src/middleware.rs
+++ b/crates/claim/src/middleware.rs
@@ -102,19 +102,22 @@ fn remove_codec_suffix(asset_id: &str) -> &str {
 /// Supports formats:
 /// - {asset_id}.m3u8 (master playlist)
 /// - {width}/{asset_id}.m3u8 (resolution playlist)
+/// - {bucket}/{asset_id}.m3u8 (bucket-prefixed master playlist)
+/// - {bucket}/{width}/{asset_id}.m3u8 (bucket-prefixed resolution playlist)
 /// - {width}/{asset_id}-{segment}.m4s (video segment)
 /// - {width}/{asset_id}-init.mp4 (init segment)
 fn parse_video_filename(filename: &str) -> Option<(String, Option<u32>, Option<u16>)> {
     // Split by path separator first
     let parts: Vec<&str> = filename.split('/').collect();
 
-    let (file_part, width) = if parts.len() == 2 {
-        // Format: {width}/{filename}
-        let width = parts[0].parse::<u16>().ok();
-        (parts[1], width)
-    } else {
+    let (file_part, width) = match parts.as_slice() {
         // Format: {filename}
-        (parts[0], None)
+        [file] => (*file, None),
+        // Format: {width}/{filename} OR {bucket}/{filename}
+        [first, file] => (*file, first.parse::<u16>().ok()),
+        // Format: {bucket}/{width}/{filename}
+        [_bucket, width, file] => (*file, width.parse::<u16>().ok()),
+        _ => return None,
     };
 
     // Check for master playlist
@@ -160,8 +163,20 @@ mod tests {
         assert_eq!(seg, None);
         assert_eq!(width, None);
 
+        // Bucket-prefixed master playlist
+        let (asset_id, seg, width) = parse_video_filename("mybucket/video123.m3u8").unwrap();
+        assert_eq!(asset_id, "video123");
+        assert_eq!(seg, None);
+        assert_eq!(width, None);
+
         // Resolution playlist
         let (asset_id, seg, width) = parse_video_filename("720/video123.m3u8").unwrap();
+        assert_eq!(asset_id, "video123");
+        assert_eq!(seg, None);
+        assert_eq!(width, Some(720));
+
+        // Bucket-prefixed resolution playlist
+        let (asset_id, seg, width) = parse_video_filename("mybucket/720/video123.m3u8").unwrap();
         assert_eq!(asset_id, "video123");
         assert_eq!(seg, None);
         assert_eq!(width, Some(720));
@@ -172,8 +187,21 @@ mod tests {
         assert_eq!(seg, Some(0));
         assert_eq!(width, Some(720));
 
+        // Bucket-prefixed init segment
+        let (asset_id, seg, width) =
+            parse_video_filename("mybucket/720/video123-init.mp4").unwrap();
+        assert_eq!(asset_id, "video123");
+        assert_eq!(seg, Some(0));
+        assert_eq!(width, Some(720));
+
         // Video segment
         let (asset_id, seg, width) = parse_video_filename("720/video123-005.m4s").unwrap();
+        assert_eq!(asset_id, "video123");
+        assert_eq!(seg, Some(5));
+        assert_eq!(width, Some(720));
+
+        // Bucket-prefixed video segment
+        let (asset_id, seg, width) = parse_video_filename("mybucket/720/video123-005.m4s").unwrap();
         assert_eq!(asset_id, "video123");
         assert_eq!(seg, Some(5));
         assert_eq!(width, Some(720));
@@ -184,8 +212,21 @@ mod tests {
         assert_eq!(seg, None);
         assert_eq!(width, None);
 
+        // Bucket-prefixed H265 master playlist
+        let (asset_id, seg, width) = parse_video_filename("mybucket/video123-h265.m3u8").unwrap();
+        assert_eq!(asset_id, "video123");
+        assert_eq!(seg, None);
+        assert_eq!(width, None);
+
         // H265 resolution playlist
         let (asset_id, seg, width) = parse_video_filename("720/video123-h265.m3u8").unwrap();
+        assert_eq!(asset_id, "video123");
+        assert_eq!(seg, None);
+        assert_eq!(width, Some(720));
+
+        // Bucket-prefixed H265 resolution playlist
+        let (asset_id, seg, width) =
+            parse_video_filename("mybucket/720/video123-h265.m3u8").unwrap();
         assert_eq!(asset_id, "video123");
         assert_eq!(seg, None);
         assert_eq!(width, Some(720));
@@ -196,8 +237,22 @@ mod tests {
         assert_eq!(seg, Some(0));
         assert_eq!(width, Some(720));
 
+        // Bucket-prefixed H265 init segment
+        let (asset_id, seg, width) =
+            parse_video_filename("mybucket/720/video123-h265-init.mp4").unwrap();
+        assert_eq!(asset_id, "video123");
+        assert_eq!(seg, Some(0));
+        assert_eq!(width, Some(720));
+
         // H265 video segment
         let (asset_id, seg, width) = parse_video_filename("720/video123-h265-005.m4s").unwrap();
+        assert_eq!(asset_id, "video123");
+        assert_eq!(seg, Some(5));
+        assert_eq!(width, Some(720));
+
+        // Bucket-prefixed H265 video segment
+        let (asset_id, seg, width) =
+            parse_video_filename("mybucket/720/video123-h265-005.m4s").unwrap();
         assert_eq!(asset_id, "video123");
         assert_eq!(seg, Some(5));
         assert_eq!(width, Some(720));

--- a/crates/core/src/api/mod.rs
+++ b/crates/core/src/api/mod.rs
@@ -3,4 +3,4 @@ pub mod routes;
 
 // Re-export public types and functions
 pub use middleware::{log_request_errors, no_auth_middleware};
-pub use routes::{create_claim, serve_video, upload_mp4_raw, waitlist};
+pub use routes::{create_claim, migrate_videos, serve_video, upload_mp4_raw, waitlist};

--- a/crates/core/src/api/routes.rs
+++ b/crates/core/src/api/routes.rs
@@ -6,14 +6,18 @@ use axum::http::{HeaderValue, Request, Response, StatusCode, header};
 use axum::response::{IntoResponse, Json};
 use bytes::Bytes;
 use futures::StreamExt;
+use opendal::EntryMode;
 use opendal::Operator;
+use opendal::options;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::convert::Infallible;
 use std::ffi::OsStr;
 use std::io::Error as IoError;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::io::AsyncSeekExt;
+use tokio_util::compat::{FuturesAsyncReadCompatExt as _, FuturesAsyncWriteCompatExt as _};
 use tokio_util::io::ReaderStream;
 use tracing::{debug, error, info, warn};
 use video_storage_claim::create_request::AssetsFilter;
@@ -32,6 +36,34 @@ pub struct WaitlistResponse {
     pub pending_convert_jobs: usize,
     pub pending_upload_jobs: usize,
     pub total_pending_jobs: usize,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MigrateResponse {
+    pub job_id: String,
+    pub src_bucket: String,
+    pub dst_bucket: String,
+    pub dry_run: bool,
+    pub objects_total: u64,
+    pub objects_copied: u64,
+    pub bytes_copied: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MigrateRequest {
+    pub job_id: String,
+    pub src_bucket: String,
+    pub dst_bucket: String,
+    #[serde(default)]
+    pub widths: Option<Vec<u16>>,
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MigrateErrorResponse {
+    pub job_id: String,
+    pub message: String,
 }
 
 /// Validate job ID with basic rules
@@ -84,6 +116,27 @@ pub async fn upload_mp4_raw(
 
     let body = request.into_body();
     let job_id = job.id().to_string();
+
+    if state.storage_manager.is_s3() {
+        let Some(dst_bucket) = job.dst_bucket.as_deref().filter(|b| !b.is_empty()) else {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(UploadResponse {
+                    job_id,
+                    message: "Missing dst_bucket (required when storage_backend is s3)".into(),
+                }),
+            );
+        };
+        if let Err(message) = validate_bucket_for_write(dst_bucket) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(UploadResponse {
+                    job_id,
+                    message: message.into(),
+                }),
+            );
+        }
+    }
 
     if job.crf > 63 {
         return (
@@ -231,41 +284,118 @@ async fn try_serve_from_s3(
     Ok(stream)
 }
 
+fn is_pure_ascii_digits(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
+}
+
+fn validate_bucket_for_write(bucket: &str) -> Result<(), &'static str> {
+    if bucket.is_empty() {
+        return Err("Invalid bucket: empty");
+    }
+    if bucket.contains('/') {
+        return Err("Invalid bucket: contains '/'");
+    }
+    if is_pure_ascii_digits(bucket) {
+        return Err("Invalid bucket: numeric-only bucket is not allowed");
+    }
+    Ok(())
+}
+
+fn split_bucket_and_key(filename: &str, is_s3: bool) -> Result<(Option<&str>, &str), &'static str> {
+    if is_s3 {
+        let Some((bucket, key)) = filename.split_once('/') else {
+            return Err("Missing bucket in /videos path");
+        };
+        if bucket.is_empty() || key.is_empty() {
+            return Err("Invalid /videos path");
+        }
+        return Ok((Some(bucket), key));
+    }
+
+    let Some((first, rest)) = filename.split_once('/') else {
+        return Ok((None, filename));
+    };
+
+    // Local backend:
+    // - Keep legacy layout: `720/<file>` (first segment is numeric width)
+    // - Allow bucket-prefixed paths: `<bucket>/<key>` by stripping the first segment
+    if first.chars().all(|c| c.is_ascii_digit()) {
+        Ok((None, filename))
+    } else if rest.is_empty() {
+        Err("Invalid /videos path")
+    } else {
+        Ok((Some(first), rest))
+    }
+}
+
+fn extract_job_id_from_key(key: &str) -> Result<&str, &'static str> {
+    let path_and_suffix = key.split('.').collect::<Vec<_>>();
+    if path_and_suffix.len() != 2 {
+        return Err("Invalid filename");
+    }
+
+    let path = path_and_suffix[0];
+    let vals = path.split('-').collect::<Vec<_>>();
+    if !(1..=3).contains(&vals.len()) {
+        return Err("Invalid filename");
+    }
+
+    let mut job_id = vals[0];
+    if let Some((_h, jid)) = vals[0].split_once('/') {
+        job_id = jid;
+    }
+
+    Ok(job_id)
+}
+
 pub async fn serve_video(
     Extension(state): Extension<AppState>,
     Extension(bucket): Extension<ClaimBucket>,
     AxumPath(filename): AxumPath<String>,
     req: Request<Body>,
 ) -> Result<Response<Body>, Infallible> {
-    let path_and_suffix = filename.split('.').collect::<Vec<_>>();
+    let is_s3 = state.storage_manager.is_s3();
+    let (bucket_prefix, key) = match split_bucket_and_key(&filename, is_s3) {
+        Ok(v) => v,
+        Err(msg) => return Ok(err_response(StatusCode::BAD_REQUEST, msg)),
+    };
 
-    if path_and_suffix.len() != 2 {
-        warn!(%filename, "Invalid filename");
-        return Ok(err_response(StatusCode::BAD_REQUEST, "Invalid filename"));
-    }
+    let operator = if is_s3 {
+        let Some(bucket_name) = bucket_prefix else {
+            return Ok(err_response(StatusCode::BAD_REQUEST, "Missing bucket"));
+        };
+        match state.storage_manager.operator_for_bucket(bucket_name) {
+            Ok(op) => Some(op),
+            Err(error) => {
+                warn!(?error, bucket = %bucket_name, "Invalid bucket");
+                return Ok(err_response(StatusCode::BAD_REQUEST, "Invalid bucket"));
+            }
+        }
+    } else {
+        None
+    };
 
-    let path = path_and_suffix[0];
-
-    let vals = path.split('-').collect::<Vec<_>>();
-
-    let len = vals.len();
-    if !(1..=3).contains(&len) {
-        warn!(%filename, "Invalid filename");
-        return Ok(err_response(StatusCode::BAD_REQUEST, "Invalid filename"));
-    }
-
-    let mut job_id = vals[0];
-
-    if let Some((_h, jid)) = vals[0].split_once("/") {
-        job_id = jid;
+    let job_id = match extract_job_id_from_key(key) {
+        Ok(v) => v,
+        Err(msg) => {
+            warn!(filename = %key, "Invalid filename");
+            return Ok(err_response(StatusCode::BAD_REQUEST, msg));
+        }
     };
 
     // First, try to get file size from local filesystem
-    let local_path = state.videos_dir().join(job_id).join(&filename);
-    let s3_key = format!("videos/{filename}");
-    debug!(%job_id, %filename, ?local_path, ?s3_key, "Request server file");
+    let local_path = state.videos_dir().join(job_id).join(key);
+    let s3_key = format!("videos/{key}");
+    debug!(
+        %job_id,
+        filename = %key,
+        bucket = bucket_prefix.unwrap_or(""),
+        ?local_path,
+        ?s3_key,
+        "Request server file"
+    );
 
-    server_file_with_bucket(state, local_path, s3_key, filename, req, bucket).await
+    server_file_with_bucket(local_path, s3_key, key.to_string(), req, bucket, operator).await
 }
 
 fn parse_range(req: &Request<Body>, file_size: u64) -> (StatusCode, u64, u64) {
@@ -286,16 +416,16 @@ fn parse_range(req: &Request<Body>, file_size: u64) -> (StatusCode, u64, u64) {
 }
 
 async fn server_file_with_bucket(
-    state: AppState,
     local_path: PathBuf,
     s3_key: String,
     filename: String,
     req: Request<Body>,
     bucket: ClaimBucket,
+    operator: Option<Operator>,
 ) -> Result<Response<Body>, Infallible> {
     let maybe_filesize = if let Ok(metadata) = tokio::fs::metadata(&local_path).await {
         Some((metadata.len(), false))
-    } else if let Some(operator) = state.storage_manager.operator() {
+    } else if let Some(operator) = operator.as_ref() {
         // Try to get size from S3
         operator
             .stat(&s3_key)
@@ -314,11 +444,7 @@ async fn server_file_with_bucket(
     let len = end - start + 1;
 
     let maybe_res = if read_from_s3 {
-        let operator = state
-            .storage_manager
-            .operator()
-            .expect("S3 operator should be available for remote storage")
-            .clone();
+        let operator = operator.expect("S3 operator should be available for remote storage");
 
         try_serve_from_s3(s3_key, start, end, operator, bucket.clone())
             .await
@@ -357,6 +483,198 @@ async fn server_file_with_bucket(
         );
     }
     Ok(res)
+}
+
+pub async fn migrate_videos(
+    Extension(state): Extension<AppState>,
+    Json(request): Json<MigrateRequest>,
+) -> impl IntoResponse {
+    let job_id = request.job_id.clone();
+
+    let migrate_err = |status: StatusCode, message: String| {
+        (
+            status,
+            Json(MigrateErrorResponse {
+                job_id: job_id.clone(),
+                message,
+            }),
+        )
+            .into_response()
+    };
+
+    if !state.storage_manager.is_s3() {
+        return migrate_err(StatusCode::BAD_REQUEST, "storage_backend is not s3".into());
+    }
+
+    if !is_valid_job_id(&job_id) {
+        return migrate_err(StatusCode::BAD_REQUEST, "Invalid job ID format".into());
+    }
+
+    if let Err(message) = validate_bucket_for_write(&request.src_bucket) {
+        return migrate_err(
+            StatusCode::BAD_REQUEST,
+            format!("Invalid src_bucket: {message}"),
+        );
+    }
+    if let Err(message) = validate_bucket_for_write(&request.dst_bucket) {
+        return migrate_err(
+            StatusCode::BAD_REQUEST,
+            format!("Invalid dst_bucket: {message}"),
+        );
+    }
+
+    let src_op = match state
+        .storage_manager
+        .operator_for_bucket(&request.src_bucket)
+    {
+        Ok(op) => op,
+        Err(error) => {
+            warn!(?error, bucket = %request.src_bucket, "Invalid src_bucket");
+            return migrate_err(StatusCode::BAD_REQUEST, "Invalid src_bucket".into());
+        }
+    };
+    let dst_op = match state
+        .storage_manager
+        .operator_for_bucket(&request.dst_bucket)
+    {
+        Ok(op) => op,
+        Err(error) => {
+            warn!(?error, bucket = %request.dst_bucket, "Invalid dst_bucket");
+            return migrate_err(StatusCode::BAD_REQUEST, "Invalid dst_bucket".into());
+        }
+    };
+
+    let widths = request.widths.unwrap_or_else(|| {
+        crate::job::convert::RESOLUTIONS
+            .iter()
+            .map(|s| u16::try_from(s.width()).expect("resolution width must fit in u16"))
+            .collect()
+    });
+    let mut prefixes = Vec::with_capacity(widths.len() + 1);
+    prefixes.push(format!("videos/{job_id}"));
+    for w in widths {
+        prefixes.push(format!("videos/{w}/{job_id}"));
+    }
+
+    let mut keys: BTreeSet<String> = BTreeSet::new();
+    for prefix in prefixes {
+        let mut lister = match src_op
+            .lister_options(
+                &prefix,
+                options::ListOptions {
+                    recursive: true,
+                    ..Default::default()
+                },
+            )
+            .await
+        {
+            Ok(lister) => lister,
+            Err(error) => {
+                error!(?error, %prefix, "Failed to list src objects");
+                return migrate_err(StatusCode::INTERNAL_SERVER_ERROR, "List failed".into());
+            }
+        };
+
+        use futures::TryStreamExt as _;
+        while let Some(entry) = match lister.try_next().await {
+            Ok(v) => v,
+            Err(error) => {
+                error!(?error, %prefix, "Failed to iterate src objects");
+                return migrate_err(StatusCode::INTERNAL_SERVER_ERROR, "List failed".into());
+            }
+        } {
+            if entry.metadata().mode() != EntryMode::FILE {
+                continue;
+            }
+            let path = entry.path();
+            let Some(rest) = path.strip_prefix(&prefix) else {
+                continue;
+            };
+            if !(rest.starts_with('.') || rest.starts_with('-')) {
+                continue;
+            }
+            _ = keys.insert(path.to_string());
+        }
+    }
+
+    let mut objects_total = 0u64;
+    let mut objects_copied = 0u64;
+    let mut bytes_copied = 0u64;
+
+    const DELETE_SOURCE_OBJECTS: bool = false;
+
+    for key in keys {
+        objects_total += 1;
+
+        let meta = match src_op.stat(&key).await {
+            Ok(m) => m,
+            Err(error) => {
+                error!(?error, %key, "Failed to stat src object");
+                return migrate_err(StatusCode::INTERNAL_SERVER_ERROR, "Stat failed".into());
+            }
+        };
+
+        let size = meta.content_length();
+        if request.dry_run {
+            bytes_copied += size;
+            objects_copied += 1;
+            continue;
+        }
+
+        let copied = match copy_object_streaming(&src_op, &dst_op, &key, meta.content_type()).await
+        {
+            Ok(v) => v,
+            Err(error) => {
+                error!(?error, %key, "Failed to copy object");
+                return migrate_err(StatusCode::INTERNAL_SERVER_ERROR, "Copy failed".into());
+            }
+        };
+
+        bytes_copied += copied;
+        objects_copied += 1;
+
+        // NOTE: Deletion is intentionally disabled in this release to prevent accidental data loss.
+        if DELETE_SOURCE_OBJECTS && let Err(error) = src_op.delete(&key).await {
+            error!(?error, %key, "Failed to delete src object");
+            return migrate_err(StatusCode::INTERNAL_SERVER_ERROR, "Delete failed".into());
+        }
+    }
+
+    (
+        StatusCode::OK,
+        Json(MigrateResponse {
+            job_id,
+            src_bucket: request.src_bucket,
+            dst_bucket: request.dst_bucket,
+            dry_run: request.dry_run,
+            objects_total,
+            objects_copied,
+            bytes_copied,
+        }),
+    )
+        .into_response()
+}
+
+async fn copy_object_streaming(
+    src: &Operator,
+    dst: &Operator,
+    key: &str,
+    content_type: Option<&str>,
+) -> anyhow::Result<u64> {
+    let reader = src.reader(key).await?;
+    let mut r = reader.into_futures_async_read(..).await?.compat();
+
+    let mut writer = dst.writer_with(key).chunk(8 * 1024 * 1024).concurrent(8);
+    if let Some(ct) = content_type {
+        writer = writer.content_type(ct);
+    }
+    let mut w = writer.await?.into_futures_async_write().compat_write();
+
+    let copied = tokio::io::copy(&mut r, &mut w).await?;
+    use tokio::io::AsyncWriteExt as _;
+    w.shutdown().await?;
+
+    Ok(copied)
 }
 
 /// Create a new claim token for video access
@@ -693,5 +1011,232 @@ mod tests {
             })
             .expect("job should be enqueued");
         assert_eq!(job_json["codecs"], serde_json::json!(["h265"]));
+    }
+
+    #[test]
+    fn test_split_bucket_and_key_local_legacy_and_bucket_prefixed() {
+        assert_eq!(
+            split_bucket_and_key("test_video.m3u8", false).unwrap(),
+            (None, "test_video.m3u8")
+        );
+        assert_eq!(
+            split_bucket_and_key("720/test_video.m3u8", false).unwrap(),
+            (None, "720/test_video.m3u8")
+        );
+        assert_eq!(
+            split_bucket_and_key("mybucket/test_video.m3u8", false).unwrap(),
+            (Some("mybucket"), "test_video.m3u8")
+        );
+        assert_eq!(
+            split_bucket_and_key("mybucket/720/test_video.m3u8", false).unwrap(),
+            (Some("mybucket"), "720/test_video.m3u8")
+        );
+    }
+
+    #[test]
+    fn test_split_bucket_and_key_s3_requires_bucket() {
+        assert!(split_bucket_and_key("test_video.m3u8", true).is_err());
+        assert_eq!(
+            split_bucket_and_key("mybucket/test_video.m3u8", true).unwrap(),
+            (Some("mybucket"), "test_video.m3u8")
+        );
+    }
+
+    #[test]
+    fn test_extract_job_id_from_key() {
+        assert_eq!(
+            extract_job_id_from_key("test_video.m3u8").unwrap(),
+            "test_video"
+        );
+        assert_eq!(
+            extract_job_id_from_key("test_video-h265.m3u8").unwrap(),
+            "test_video"
+        );
+        assert_eq!(
+            extract_job_id_from_key("720/test_video.m3u8").unwrap(),
+            "test_video"
+        );
+        assert_eq!(
+            extract_job_id_from_key("720/test_video-h265-001.m4s").unwrap(),
+            "test_video"
+        );
+        assert!(extract_job_id_from_key("bad.name.m3u8").is_err());
+        assert!(extract_job_id_from_key("a-b-c-d.m3u8").is_err());
+    }
+
+    #[test]
+    fn test_validate_bucket_for_write_rejects_numeric_only() {
+        assert!(validate_bucket_for_write("mybucket").is_ok());
+        assert!(validate_bucket_for_write("123").is_err());
+        assert!(validate_bucket_for_write("bucket/123").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_upload_mp4_raw_requires_dst_bucket_when_s3() {
+        use crate::opendal::{StorageBackend, StorageConfig, StorageManager};
+        use axum::body::Body;
+        use axum::http::Request;
+        use tempfile::tempdir;
+
+        let temp_dir = tempdir().unwrap();
+        let storage_manager = StorageManager::new(StorageConfig {
+            backend: StorageBackend::S3 {
+                endpoint: Some("http://127.0.0.1:9000".into()),
+                region: Some("us-east-1".into()),
+                access_key_id: "minioadmin".into(),
+                secret_access_key: "minioadmin".into(),
+            },
+            workspace: temp_dir.path().to_path_buf(),
+        })
+        .await
+        .unwrap();
+
+        let state = AppState::new(0, temp_dir.path(), storage_manager, None, Vec::new())
+            .await
+            .unwrap();
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/upload?id=test123&crf=23")
+            .header(header::CONTENT_TYPE, "video/mp4")
+            .body(Body::from("fake mp4 data"))
+            .unwrap();
+
+        let response = upload_mp4_raw(Extension(state), request)
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let upload_response: UploadResponse = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(upload_response.job_id, "test123");
+        assert!(upload_response.message.contains("dst_bucket"));
+    }
+
+    #[tokio::test]
+    async fn test_upload_mp4_raw_rejects_numeric_only_dst_bucket_when_s3() {
+        use crate::opendal::{StorageBackend, StorageConfig, StorageManager};
+        use axum::body::Body;
+        use axum::http::Request;
+        use tempfile::tempdir;
+
+        let temp_dir = tempdir().unwrap();
+        let storage_manager = StorageManager::new(StorageConfig {
+            backend: StorageBackend::S3 {
+                endpoint: Some("http://127.0.0.1:9000".into()),
+                region: Some("us-east-1".into()),
+                access_key_id: "minioadmin".into(),
+                secret_access_key: "minioadmin".into(),
+            },
+            workspace: temp_dir.path().to_path_buf(),
+        })
+        .await
+        .unwrap();
+
+        let state = AppState::new(0, temp_dir.path(), storage_manager, None, Vec::new())
+            .await
+            .unwrap();
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/upload?id=test123&crf=23&dst_bucket=123")
+            .header(header::CONTENT_TYPE, "video/mp4")
+            .body(Body::from("fake mp4 data"))
+            .unwrap();
+
+        let response = upload_mp4_raw(Extension(state), request)
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let upload_response: UploadResponse = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(upload_response.job_id, "test123");
+        assert!(upload_response.message.contains("numeric-only"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_videos_requires_s3_backend() {
+        use crate::opendal::{StorageBackend, StorageConfig, StorageManager};
+        use tempfile::tempdir;
+
+        let temp_dir = tempdir().unwrap();
+        let storage_manager = StorageManager::new(StorageConfig {
+            backend: StorageBackend::Local,
+            workspace: temp_dir.path().to_path_buf(),
+        })
+        .await
+        .unwrap();
+
+        let state = AppState::new(0, temp_dir.path(), storage_manager, None, Vec::new())
+            .await
+            .unwrap();
+
+        let request = MigrateRequest {
+            src_bucket: "src".into(),
+            dst_bucket: "dst".into(),
+            job_id: "test123".into(),
+            dry_run: true,
+            widths: None,
+        };
+
+        let response = migrate_videos(Extension(state), Json(request))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let err: MigrateErrorResponse = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(err.job_id, "test123");
+        assert!(err.message.contains("not s3"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_videos_rejects_numeric_only_buckets() {
+        use crate::opendal::{StorageBackend, StorageConfig, StorageManager};
+        use tempfile::tempdir;
+
+        let temp_dir = tempdir().unwrap();
+        let storage_manager = StorageManager::new(StorageConfig {
+            backend: StorageBackend::S3 {
+                endpoint: Some("http://127.0.0.1:9000".into()),
+                region: Some("us-east-1".into()),
+                access_key_id: "minioadmin".into(),
+                secret_access_key: "minioadmin".into(),
+            },
+            workspace: temp_dir.path().to_path_buf(),
+        })
+        .await
+        .unwrap();
+
+        let state = AppState::new(0, temp_dir.path(), storage_manager, None, Vec::new())
+            .await
+            .unwrap();
+
+        let request = MigrateRequest {
+            src_bucket: "123".into(),
+            dst_bucket: "dst".into(),
+            job_id: "test123".into(),
+            dry_run: true,
+            widths: None,
+        };
+
+        let response = migrate_videos(Extension(state), Json(request))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let err: MigrateErrorResponse = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(err.job_id, "test123");
+        assert!(err.message.contains("numeric-only"));
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -22,7 +22,6 @@ use std::path::Path;
 /// storage_backend = "s3"  # Options: "local" or "s3"
 ///
 /// # S3 configuration (required when storage_backend = "s3")
-/// s3_bucket = "my-video-bucket"
 /// s3_endpoint = "http://localhost:9000"  # Optional: for MinIO or custom S3
 /// s3_region = "us-east-1"                # Optional
 /// s3_access_key_id = "minioadmin"
@@ -68,11 +67,6 @@ pub struct Config {
     #[arg(short, long, default_value = "local")]
     #[serde(default = "default_storage_backend")]
     pub storage_backend: String,
-
-    /// S3 bucket name (required when storage-backend is s3)
-    #[arg(long)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub s3_bucket: Option<String>,
 
     /// S3 endpoint (for MinIO/custom S3)
     #[arg(long)]
@@ -183,7 +177,6 @@ impl Default for Config {
             workspace: default_workspace(),
             config: None,
             storage_backend: default_storage_backend(),
-            s3_bucket: None,
             s3_endpoint: None,
             s3_region: None,
             s3_access_key_id: None,
@@ -250,9 +243,6 @@ impl Config {
         }
 
         // For Option fields, CLI takes precedence if Some
-        if self.s3_bucket.is_none() {
-            self.s3_bucket = file_config.s3_bucket;
-        }
         if self.s3_endpoint.is_none() {
             self.s3_endpoint = file_config.s3_endpoint;
         }
@@ -284,16 +274,6 @@ impl Config {
                 // Local storage doesn't need additional validation
             }
             "s3" => {
-                if self
-                    .s3_bucket
-                    .as_ref()
-                    .map(|s| s.is_empty())
-                    .unwrap_or(true)
-                {
-                    return Err(anyhow::anyhow!(
-                        "S3 bucket name is required when backend is 's3'"
-                    ));
-                }
                 if self
                     .s3_access_key_id
                     .as_ref()
@@ -345,7 +325,6 @@ impl Config {
         }
 
         Some(S3Config {
-            bucket: self.s3_bucket.clone()?,
             endpoint: self.s3_endpoint.clone(),
             region: self.s3_region.clone(),
             access_key_id: self.s3_access_key_id.clone()?,
@@ -364,7 +343,6 @@ impl Config {
 // S3 configuration subset
 #[derive(Debug, Clone)]
 pub struct S3Config {
-    pub bucket: String,
     pub endpoint: Option<String>,
     pub region: Option<String>,
     pub access_key_id: String,

--- a/crates/core/src/job/convert.rs
+++ b/crates/core/src/job/convert.rs
@@ -220,6 +220,13 @@ pub struct ConvertJob {
     pub id: String,
     pub crf: u8, // 0-63
 
+    /// Destination bucket for uploading HLS outputs when storage backend is S3.
+    ///
+    /// For local storage backend, this field is ignored.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dst_bucket: Option<String>,
+
     #[serde(default)]
     #[serde(skip_serializing_if = "Scales::skip_serialize")]
     pub scales: Scales,
@@ -238,6 +245,7 @@ impl ConvertJob {
         Self {
             id,
             crf,
+            dst_bucket: None,
             scales,
             codecs: ConvertCodecs::default(),
             retry_times: Arc::new(AtomicU8::new(0)),
@@ -301,8 +309,8 @@ impl Job for ConvertJob {
     }
 
     fn next_job(&self, state: AppState) -> Option<impl Job> {
-        if state.storage_manager.operator().is_some() {
-            let next = UploadJob::new(self.id.clone());
+        if state.storage_manager.is_s3() {
+            let next = UploadJob::new(self.id.clone(), self.dst_bucket.clone());
 
             let next_c = next.clone();
             let state_c = state.clone();
@@ -792,6 +800,7 @@ mod tests {
         let job = ConvertJob {
             id: "test-job-4".to_string(),
             crf: 20,
+            dst_bucket: None,
             scales: Scales::new(),
             codecs: ConvertCodecs::default(),
             retry_times: Arc::new(0.into()),
@@ -812,6 +821,7 @@ mod tests {
         let job = ConvertJob {
             id: "test-job-5".to_string(),
             crf: 18,
+            dst_bucket: None,
             scales: Scales::from_vec(Vec::new()),
             codecs: ConvertCodecs::default(),
             retry_times: Arc::new(0.into()),
@@ -837,6 +847,7 @@ mod tests {
         let job = ConvertJob {
             id: "test-job-6".to_string(),
             crf: 22,
+            dst_bucket: None,
             scales: Scales::from_vec(custom_scales),
             codecs: ConvertCodecs::default(),
             retry_times: Arc::new(0.into()),
@@ -861,6 +872,7 @@ mod tests {
         let original_job = ConvertJob {
             id: "round-trip-1".to_string(),
             crf: 24,
+            dst_bucket: None,
             scales: Scales::new(),
             codecs: ConvertCodecs::default(),
             retry_times: Arc::new(0.into()),
@@ -883,6 +895,7 @@ mod tests {
         let original_job = ConvertJob {
             id: "round-trip-2".to_string(),
             crf: 26,
+            dst_bucket: None,
             scales: Scales::from_vec(custom_scales.clone()),
             codecs: ConvertCodecs::default(),
             retry_times: Arc::new(0.into()),

--- a/crates/core/src/job/upload.rs
+++ b/crates/core/src/job/upload.rs
@@ -1,19 +1,27 @@
 use crate::app_state::AppState;
 use crate::job::{Action, FailureJob, Job, JobKind, UPLOAD_KIND};
+use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::task::JoinHandle as TokioJoinHandle;
 use tracing::error;
 
+fn is_pure_ascii_digits(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UploadJob {
     pub id: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dst_bucket: Option<String>,
 }
 
 impl UploadJob {
-    pub fn new(id: String) -> Self {
-        Self { id }
+    pub fn new(id: String, dst_bucket: Option<String>) -> Self {
+        Self { id, dst_bucket }
     }
 
     pub fn id(&self) -> &str {
@@ -42,11 +50,30 @@ impl Job for UploadJob {
     fn gen_job(&self, state: AppState) -> TokioJoinHandle<anyhow::Result<()>> {
         let upload_path = self.video_path(state.videos_dir());
         let job_id = self.id.clone();
+        let dst_bucket = self.dst_bucket.clone();
 
         tokio::spawn(async move {
+            if !state.storage_manager.is_s3() {
+                return Ok(());
+            }
+
+            let Some(dst_bucket) = dst_bucket.filter(|b| !b.is_empty()) else {
+                return Err(anyhow!(
+                    "dst_bucket is required for upload job when storage backend is S3"
+                ));
+            };
+            if dst_bucket.contains('/') {
+                return Err(anyhow!("Invalid dst_bucket: contains '/'"));
+            }
+            if is_pure_ascii_digits(&dst_bucket) {
+                return Err(anyhow!(
+                    "Invalid dst_bucket: numeric-only bucket is not allowed"
+                ));
+            }
+
             state
                 .storage_manager
-                .upload_directory(&upload_path, "videos")
+                .upload_directory_to_bucket(&dst_bucket, &upload_path, "videos")
                 .await
                 .map(|_| {
                     _ = std::fs::remove_dir_all(upload_path);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,7 +21,9 @@ use tracing::info;
 //
 // Re-export
 //
-pub use api::{create_claim, log_request_errors, serve_video, upload_mp4_raw, waitlist};
+pub use api::{
+    create_claim, log_request_errors, migrate_videos, serve_video, upload_mp4_raw, waitlist,
+};
 pub use app_state::AppState;
 pub use config::Config;
 pub use job::{ConvertJob, Job, JobResult, UploadJob};
@@ -52,7 +54,6 @@ pub async fn run(config: Config) {
                 .to_s3_config()
                 .expect("S3 configuration is required when using S3 backend");
             StorageBackend::S3 {
-                bucket: s3_config.bucket,
                 endpoint: s3_config.endpoint,
                 region: s3_config.region,
                 access_key_id: s3_config.access_key_id,
@@ -111,6 +112,7 @@ pub async fn run(config: Config) {
     let internal_app = Router::new()
         .route("/claims", post(create_claim))
         .route("/upload", post(upload_mp4_raw))
+        .route("/migrate", post(migrate_videos))
         .route("/waitlist", get(waitlist))
         .route("/videos/{*filename}", get(serve_video))
         .layer(axum::middleware::from_fn(api::log_request_errors))

--- a/crates/core/src/opendal.rs
+++ b/crates/core/src/opendal.rs
@@ -3,7 +3,8 @@ use async_stream::try_stream;
 use futures::StreamExt;
 use opendal::services::S3;
 use opendal::{Operator, layers::RetryLayer};
-use std::collections::VecDeque;
+use parking_lot::RwLock;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -21,7 +22,6 @@ pub struct StorageConfig {
 pub enum StorageBackend {
     Local,
     S3 {
-        bucket: String,
         endpoint: Option<String>,
         region: Option<String>,
         access_key_id: String,
@@ -32,60 +32,95 @@ pub enum StorageBackend {
 /// Storage manager to handle different storage backends
 #[derive(Clone)]
 pub struct StorageManager {
-    operator: Option<Operator>,
+    backend: StorageBackend,
+    s3_operators: Arc<RwLock<HashMap<String, Operator>>>,
 }
 
 impl StorageManager {
     pub async fn new(config: StorageConfig) -> Result<Self> {
-        let operator = match &config.backend {
+        match &config.backend {
             StorageBackend::Local => {
-                info!("Using local filesystem storage - no OpenDAL operator needed");
-                None
+                info!("Using local filesystem storage");
             }
             StorageBackend::S3 {
-                bucket,
                 endpoint,
                 region,
-                access_key_id,
-                secret_access_key,
+                access_key_id: _,
+                secret_access_key: _,
             } => {
-                let op = build_s3_operator(
-                    bucket,
-                    endpoint.as_deref(),
-                    region.as_deref(),
-                    access_key_id,
-                    secret_access_key,
-                )?;
-                Some(op)
-            }
-        };
-
-        Ok(Self { operator })
-    }
-
-    pub fn operator(&self) -> Option<&Operator> {
-        self.operator.as_ref()
-    }
-
-    pub async fn upload_directory(&self, local_path: &Path, remote_prefix: &str) -> Result<()> {
-        match &self.operator {
-            None => {
-                // For local storage, no upload needed
-                info!(?local_path, "Using local storage, skipping upload");
-                Ok(())
-            }
-            Some(operator) => {
-                info!(?local_path, %remote_prefix, "Starting directory upload to remote storage");
-
-                upload_tree_streaming(
-                    operator.clone(),
-                    local_path,
-                    remote_prefix,
-                    8, // concurrency
-                )
-                .await
+                info!(
+                    endpoint = ?endpoint,
+                    region = ?region,
+                    "Using S3 storage backend (bucket selected per request/job)"
+                );
             }
         }
+
+        Ok(Self {
+            backend: config.backend,
+            s3_operators: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+
+    pub fn is_s3(&self) -> bool {
+        matches!(self.backend, StorageBackend::S3 { .. })
+    }
+
+    pub fn operator_for_bucket(&self, bucket: &str) -> Result<Operator> {
+        if bucket.is_empty() || bucket.contains('/') {
+            return Err(anyhow!("Invalid bucket name"));
+        }
+
+        let StorageBackend::S3 {
+            endpoint,
+            region,
+            access_key_id,
+            secret_access_key,
+        } = &self.backend
+        else {
+            return Err(anyhow!(
+                "S3 operator requested but storage backend is not S3"
+            ));
+        };
+
+        if let Some(op) = self.s3_operators.read().get(bucket).cloned() {
+            return Ok(op);
+        }
+
+        let op = build_s3_operator(
+            bucket,
+            endpoint.as_deref(),
+            region.as_deref(),
+            access_key_id,
+            secret_access_key,
+        )?;
+
+        let mut w = self.s3_operators.write();
+        Ok(w.entry(bucket.to_string())
+            .or_insert_with(|| op.clone())
+            .clone())
+    }
+
+    pub async fn upload_directory_to_bucket(
+        &self,
+        bucket: &str,
+        local_path: &Path,
+        remote_prefix: &str,
+    ) -> Result<()> {
+        if !self.is_s3() {
+            info!(?local_path, "Using local storage, skipping upload");
+            return Ok(());
+        }
+
+        let operator = self.operator_for_bucket(bucket)?;
+
+        info!(
+            ?local_path,
+            %remote_prefix,
+            %bucket,
+            "Starting directory upload to remote storage"
+        );
+        upload_tree_streaming(operator, local_path, remote_prefix, 8).await
     }
 }
 
@@ -253,6 +288,25 @@ async fn upload_one(op: &Operator, local_root: &Path, file: &Path, prefix: &str)
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_operator_for_bucket_requires_s3_backend() {
+        let temp_dir = tempdir().unwrap();
+        let manager = StorageManager::new(StorageConfig {
+            backend: StorageBackend::Local,
+            workspace: temp_dir.path().to_path_buf(),
+        })
+        .await
+        .unwrap();
+
+        assert!(manager.operator_for_bucket("any").is_err());
+    }
+}
+
+#[cfg(test)]
+mod smoke_tests {
     use super::*;
 
     #[tokio::test]

--- a/crates/core/tests/auth_integration_test.rs
+++ b/crates/core/tests/auth_integration_test.rs
@@ -4,6 +4,8 @@ use std::time::UNIX_EPOCH;
 use tokio::time::sleep;
 use video_storage_test_server::{CreateClaimRequest, CreateClaimResponse, TestServer};
 
+const TEST_BUCKET: &str = "testbucket";
+
 #[tokio::test]
 async fn test_server_starts_successfully() {
     let server = TestServer::shared().await;
@@ -26,13 +28,16 @@ async fn test_no_auth_fails() {
 
     // Request from internal URL should fail
     let response = server
-        .get_without_auth(&client, "/videos/test_video.m3u8")
+        .get_without_auth(&client, &format!("/videos/{TEST_BUCKET}/test_video.m3u8"))
         .await;
     assert_eq!(response.status(), 404);
 
     // Request without Authorization header should fail
     let response = client
-        .get(format!("{}/videos/test_video.m3u8", server.ext_url()))
+        .get(format!(
+            "{}/videos/{TEST_BUCKET}/test_video.m3u8",
+            server.ext_url()
+        ))
         .send()
         .await
         .unwrap();
@@ -40,7 +45,10 @@ async fn test_no_auth_fails() {
 
     // Request with invalid Authorization header should fail
     let response = client
-        .get(format!("{}/videos/test_video.m3u8", server.ext_url()))
+        .get(format!(
+            "{}/videos/{TEST_BUCKET}/test_video.m3u8",
+            server.ext_url()
+        ))
         .header("Authorization", "InvalidToken")
         .send()
         .await
@@ -61,7 +69,11 @@ async fn test_valid_auth_succeeds() {
 
     // Request with valid token should succeed (would return NOT_FOUND since file doesn't exist)
     let response = server
-        .get_with_auth(&client, "/videos/test_video.m3u8", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/test_video.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 404);
 }
@@ -79,7 +91,11 @@ async fn test_asset_id_mismatch() {
 
     // Try to access video2 with video1's token
     let response = server
-        .get_with_auth(&client, "/videos/video2.m3u8", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/video2.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 403);
 }
@@ -99,7 +115,11 @@ async fn test_expired_token() {
 
     // Request with expired token should fail
     let response = server
-        .get_with_auth(&client, "/videos/test_video.m3u8", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/test_video.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 401);
 }
@@ -117,19 +137,31 @@ async fn test_width_restrictions() {
 
     // Accessing allowed width should succeed (would return NOT_FOUND since file doesn't exist)
     let response = server
-        .get_with_auth(&client, "/videos/720/test_video.m3u8", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/720/test_video.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 404);
 
     // Accessing disallowed width should fail
     let response = server
-        .get_with_auth(&client, "/videos/1920/test_video.m3u8", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/1920/test_video.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 403);
 
     // Master playlist (no width) should always be allowed
     let response = server
-        .get_with_auth(&client, "/videos/test_video.m3u8", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/test_video.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 404);
 }
@@ -150,7 +182,7 @@ async fn test_empty_allowed_widths_allows_all() {
         let response = server
             .get_with_auth(
                 &client,
-                &format!("/videos/{}/test_video.m3u8", width),
+                &format!("/videos/{TEST_BUCKET}/{}/test_video.m3u8", width),
                 &token,
             )
             .await;
@@ -191,13 +223,21 @@ async fn test_time_window_for_segments() {
 
     // Segment 20 should be allowed (within 30 segment window)
     let response = server
-        .get_with_auth(&client, "/videos/test_video-020.m4s", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/test_video-020.m4s"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 404);
 
     // Segment 40 should be denied (outside 30 segment window)
     let response = server
-        .get_with_auth(&client, "/videos/test_video-040.m4s", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/test_video-040.m4s"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 403);
 }
@@ -209,7 +249,10 @@ async fn test_invalid_claim_token() {
 
     // Test with malformed token
     let response = client
-        .get(format!("{}/videos/test_video.m3u8", server.ext_url()))
+        .get(format!(
+            "{}/videos/{TEST_BUCKET}/test_video.m3u8",
+            server.ext_url()
+        ))
         .header("Authorization", "Bearer invalid_base64_token!!!")
         .send()
         .await
@@ -218,7 +261,10 @@ async fn test_invalid_claim_token() {
 
     // Test with random base64 token
     let response = client
-        .get(format!("{}/videos/test_video.m3u8", server.ext_url()))
+        .get(format!(
+            "{}/videos/{TEST_BUCKET}/test_video.m3u8",
+            server.ext_url()
+        ))
         .header("Authorization", "Bearer YmFkX3Rva2Vu") // "bad_token" in base64
         .send()
         .await
@@ -239,19 +285,31 @@ async fn test_width_restrictions_with_segments() {
 
     // Init segment with allowed width should pass
     let response = server
-        .get_with_auth(&client, "/videos/720/test_video-init.mp4", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/720/test_video-init.mp4"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 404);
 
     // Video segment with allowed width should pass
     let response = server
-        .get_with_auth(&client, "/videos/720/test_video-001.m4s", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/720/test_video-001.m4s"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 404);
 
     // Video segment with disallowed width should fail
     let response = server
-        .get_with_auth(&client, "/videos/1080/test_video-001.m4s", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/1080/test_video-001.m4s"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 403);
 }
@@ -266,13 +324,14 @@ async fn test_h265_paths_strip_codec_suffix() {
         .await
         .expect("Failed to create claim");
 
-    for path in [
-        "/videos/test_video-h265.m3u8",
-        "/videos/720/test_video-h265.m3u8",
-        "/videos/720/test_video-h265-init.mp4",
-        "/videos/720/test_video-h265-001.m4s",
-    ] {
-        let response = server.get_with_auth(&client, path, &token).await;
+    let paths = vec![
+        format!("/videos/{TEST_BUCKET}/test_video-h265.m3u8"),
+        format!("/videos/{TEST_BUCKET}/720/test_video-h265.m3u8"),
+        format!("/videos/{TEST_BUCKET}/720/test_video-h265-init.mp4"),
+        format!("/videos/{TEST_BUCKET}/720/test_video-h265-001.m4s"),
+    ];
+    for path in paths {
+        let response = server.get_with_auth(&client, &path, &token).await;
         assert_eq!(response.status(), 404, "expected 404 for {}", path);
     }
 }
@@ -293,7 +352,7 @@ async fn test_multiple_width_restrictions() {
         let response = server
             .get_with_auth(
                 &client,
-                &format!("/videos/{}/test_video.m3u8", width),
+                &format!("/videos/{TEST_BUCKET}/{}/test_video.m3u8", width),
                 &token,
             )
             .await;
@@ -305,7 +364,7 @@ async fn test_multiple_width_restrictions() {
         let response = server
             .get_with_auth(
                 &client,
-                &format!("/videos/{}/test_video.m3u8", width),
+                &format!("/videos/{TEST_BUCKET}/{}/test_video.m3u8", width),
                 &token,
             )
             .await;
@@ -333,7 +392,10 @@ async fn test_concurrent_requests() {
         let client_c = client.clone();
         let handle = tokio::spawn(async move {
             let response = client_c
-                .get(format!("{}/videos/test_video-{:03}.m4s", base_url, i))
+                .get(format!(
+                    "{}/videos/{TEST_BUCKET}/test_video-{:03}.m4s",
+                    base_url, i
+                ))
                 .header("Authorization", format!("Bearer {}", token_clone))
                 .send()
                 .await
@@ -482,14 +544,22 @@ async fn test_v2_claim_creation_and_auth() {
     // Test that all included assets are accessible
     for asset_id in &["video1", "video2", "video3"] {
         let response = server
-            .get_with_auth(&client, &format!("/videos/{}.m3u8", asset_id), &token)
+            .get_with_auth(
+                &client,
+                &format!("/videos/{TEST_BUCKET}/{}.m3u8", asset_id),
+                &token,
+            )
             .await;
         assert_eq!(response.status(), 404); // File doesn't exist but auth passes
     }
 
     // Test that non-included assets are rejected
     let response = server
-        .get_with_auth(&client, "/videos/video4.m3u8", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/video4.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 403);
 }
@@ -508,13 +578,21 @@ async fn test_v2_claim_single_asset_in_list() {
 
     // Should work for the included asset
     let response = server
-        .get_with_auth(&client, "/videos/single_video.m3u8", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/single_video.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 404);
 
     // Should reject other assets
     let response = server
-        .get_with_auth(&client, "/videos/other_video.m3u8", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/other_video.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 403);
 }
@@ -536,7 +614,7 @@ async fn test_v2_claim_with_width_restrictions() {
         let response = server
             .get_with_auth(
                 &client,
-                &format!("/videos/{}/test_video.m3u8", width),
+                &format!("/videos/{TEST_BUCKET}/{}/test_video.m3u8", width),
                 &token,
             )
             .await;
@@ -545,13 +623,21 @@ async fn test_v2_claim_with_width_restrictions() {
 
     // Test disallowed width
     let response = server
-        .get_with_auth(&client, "/videos/1920/test_video.m3u8", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/1920/test_video.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 403);
 
     // Master playlist (no width) should be allowed
     let response = server
-        .get_with_auth(&client, "/videos/test_video.m3u8", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/test_video.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 404);
 }
@@ -570,24 +656,40 @@ async fn test_v2_claim_segments_and_widths() {
 
     // Test segments with correct width for included assets
     let response = server
-        .get_with_auth(&client, "/videos/480/video_a-001.m4s", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/480/video_a-001.m4s"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 404);
 
     let response = server
-        .get_with_auth(&client, "/videos/480/video_b-init.mp4", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/480/video_b-init.mp4"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 404);
 
     // Test segments with wrong width
     let response = server
-        .get_with_auth(&client, "/videos/720/video_a-001.m4s", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/720/video_a-001.m4s"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 403);
 
     // Test segments for non-included asset
     let response = server
-        .get_with_auth(&client, "/videos/480/video_c-001.m4s", &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/480/video_c-001.m4s"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 403);
 }
@@ -626,12 +728,20 @@ async fn test_v2_claim_time_window_validation() {
     // Both assets should work within time window for allowed segments
     for asset_id in &["video1", "video2"] {
         let response = server
-            .get_with_auth(&client, &format!("/videos/{}-020.m4s", asset_id), &token)
+            .get_with_auth(
+                &client,
+                &format!("/videos/{TEST_BUCKET}/{}-020.m4s", asset_id),
+                &token,
+            )
             .await;
         assert_eq!(response.status(), 404); // Within window
 
         let response = server
-            .get_with_auth(&client, &format!("/videos/{}-040.m4s", asset_id), &token)
+            .get_with_auth(
+                &client,
+                &format!("/videos/{TEST_BUCKET}/{}-040.m4s", asset_id),
+                &token,
+            )
             .await;
         assert_eq!(response.status(), 403); // Outside window
     }
@@ -692,7 +802,10 @@ async fn test_v2_claim_concurrent_requests() {
 
         let handle = tokio::spawn(async move {
             let response = client_c
-                .get(format!("{}/videos/{}-{:03}.m4s", base_url, asset_id, i))
+                .get(format!(
+                    "{}/videos/{TEST_BUCKET}/{}-{:03}.m4s",
+                    base_url, asset_id, i
+                ))
                 .header("Authorization", format!("Bearer {}", token_clone))
                 .send()
                 .await

--- a/crates/core/tests/convert_integration_test.rs
+++ b/crates/core/tests/convert_integration_test.rs
@@ -3,6 +3,8 @@ use serde_json::Value as JsonValue;
 use video_storage_core::job::convert::{Scale, Scales};
 use video_storage_test_server::TestServer;
 
+const TEST_BUCKET: &str = "testbucket";
+
 /// Test 480p-only conversion with test.mp4 and webhook monitoring
 #[tokio::test]
 async fn test_480p_conversion() {
@@ -82,17 +84,29 @@ async fn test_480p_conversion() {
         .expect("Failed to create claim");
 
     let response = server
-        .get_with_auth(&client, &format!("/videos/{job_id}.m3u8"), &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/{job_id}.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 200);
 
     let response = server
-        .get_with_auth(&client, &format!("/videos/480/{job_id}.m3u8"), &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/480/{job_id}.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 200);
 
     let response = server
-        .get_with_auth(&client, &format!("/videos/720/{job_id}.m3u8"), &token)
+        .get_with_auth(
+            &client,
+            &format!("/videos/{TEST_BUCKET}/720/{job_id}.m3u8"),
+            &token,
+        )
         .await;
     assert_eq!(response.status(), 404);
 }

--- a/crates/core/tests/s3_optional_integration_test.rs
+++ b/crates/core/tests/s3_optional_integration_test.rs
@@ -1,0 +1,186 @@
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use opendal::Operator;
+use video_storage_core::api::routes::{MigrateRequest, MigrateResponse};
+use video_storage_core::{StorageBackend, StorageConfig, StorageManager};
+use video_storage_test_server::TestServer;
+
+fn required_env(name: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| {
+        panic!(
+            "missing env {name}. This test is #[ignore] by default; provide all VS_TEST_S3_* env vars to run it."
+        )
+    })
+}
+
+async fn build_operator_for_bucket(
+    endpoint: Option<String>,
+    region: Option<String>,
+    access_key_id: String,
+    secret_access_key: String,
+    bucket: &str,
+) -> Operator {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage_manager = StorageManager::new(StorageConfig {
+        backend: StorageBackend::S3 {
+            endpoint,
+            region,
+            access_key_id,
+            secret_access_key,
+        },
+        workspace: tmp.path().to_path_buf(),
+    })
+    .await
+    .unwrap();
+    storage_manager.operator_for_bucket(bucket).unwrap()
+}
+
+fn unique_job_id(prefix: &str) -> String {
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+    format!("{prefix}{now_ms}")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn test_s3_serve_and_migrate_between_buckets_minio() {
+    let endpoint = required_env("VS_TEST_S3_ENDPOINT");
+    let region = std::env::var("VS_TEST_S3_REGION")
+        .ok()
+        .filter(|v| !v.is_empty());
+    let access_key_id = required_env("VS_TEST_S3_ACCESS_KEY_ID");
+    let secret_access_key = required_env("VS_TEST_S3_SECRET_ACCESS_KEY");
+    let src_bucket = required_env("VS_TEST_S3_SRC_BUCKET");
+    let dst_bucket = required_env("VS_TEST_S3_DST_BUCKET");
+
+    let server = TestServer::start_with_config(|cfg| {
+        cfg.storage_backend = "s3".into();
+        cfg.s3_endpoint = Some(endpoint.clone());
+        cfg.s3_region = region.clone();
+        cfg.s3_access_key_id = Some(access_key_id.clone());
+        cfg.s3_secret_access_key = Some(secret_access_key.clone());
+    })
+    .await;
+
+    let client = server.client();
+    let job_id = unique_job_id("s3it");
+
+    let src_op = build_operator_for_bucket(
+        Some(endpoint.clone()),
+        region.clone(),
+        access_key_id.clone(),
+        secret_access_key.clone(),
+        &src_bucket,
+    )
+    .await;
+    let dst_op = build_operator_for_bucket(
+        Some(endpoint.clone()),
+        region.clone(),
+        access_key_id,
+        secret_access_key,
+        &dst_bucket,
+    )
+    .await;
+
+    let keys = [
+        format!("videos/{job_id}.m3u8"),
+        format!("videos/{job_id}-001.m4s"),
+        format!("videos/480/{job_id}.m3u8"),
+        format!("videos/480/{job_id}-001.m4s"),
+    ];
+
+    let master_playlist = b"#EXTM3U\n#EXT-X-VERSION:3\n";
+    let variant_playlist = b"#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:4\n";
+    let segment_bytes = b"fake-segment";
+
+    // Best-effort cleanup before seeding (in case previous runs left data behind).
+    for key in &keys {
+        let _ = src_op.delete(key).await;
+        let _ = dst_op.delete(key).await;
+    }
+
+    src_op
+        .write(&keys[0], master_playlist.to_vec())
+        .await
+        .unwrap();
+    src_op
+        .write(&keys[1], segment_bytes.to_vec())
+        .await
+        .unwrap();
+    src_op
+        .write(&keys[2], variant_playlist.to_vec())
+        .await
+        .unwrap();
+    src_op
+        .write(&keys[3], segment_bytes.to_vec())
+        .await
+        .unwrap();
+
+    let token = server
+        .create_claim(&client, &job_id, vec![], 3600)
+        .await
+        .unwrap();
+
+    // Serve from src bucket via external (claim-protected) endpoint.
+    let response = server
+        .get_with_auth(
+            &client,
+            &format!("/videos/{src_bucket}/{job_id}.m3u8"),
+            &token,
+        )
+        .await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.bytes().await.unwrap().as_ref(), master_playlist);
+
+    // Migrate only 480p + master prefixes.
+    let request = MigrateRequest {
+        job_id: job_id.clone(),
+        src_bucket: src_bucket.clone(),
+        dst_bucket: dst_bucket.clone(),
+        widths: Some(vec![480]),
+        dry_run: false,
+    };
+    let response = client
+        .post(format!("{}/migrate", server.int_url()))
+        .json(&request)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    let migrate: MigrateResponse = response.json().await.unwrap();
+    assert_eq!(migrate.job_id, job_id);
+    assert_eq!(migrate.src_bucket, src_bucket);
+    assert_eq!(migrate.dst_bucket, dst_bucket);
+    assert!(!migrate.dry_run);
+    assert_eq!(migrate.objects_total, 4);
+    assert_eq!(migrate.objects_copied, 4);
+
+    // Verify objects exist in dst bucket and can be served.
+    assert_eq!(
+        dst_op.read(&keys[0]).await.unwrap().to_bytes().as_ref(),
+        master_playlist
+    );
+    assert_eq!(
+        dst_op.read(&keys[2]).await.unwrap().to_bytes().as_ref(),
+        variant_playlist
+    );
+
+    let response = server
+        .get_with_auth(
+            &client,
+            &format!("/videos/{dst_bucket}/{job_id}.m3u8"),
+            &token,
+        )
+        .await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.bytes().await.unwrap().as_ref(), master_playlist);
+
+    // Best-effort cleanup after the test.
+    for key in &keys {
+        let _ = src_op.delete(key).await;
+        let _ = dst_op.delete(key).await;
+    }
+}

--- a/crates/ez-ffmpeg/Cargo.toml
+++ b/crates/ez-ffmpeg/Cargo.toml
@@ -53,6 +53,7 @@ rtmp = ["dep:rml_rtmp", "dep:slab", "dep:dashmap", "flv"]
 flv = ["dep:bytes", "dep:byteorder"]
 static = ["ffmpeg-next/static"]
 docs-rs = ["async", "opengl", "rtmp", "flv"]
+cargo-clippy = []
 
 [package.metadata.docs.rs]
 features = ["docs-rs"]

--- a/crates/ez-ffmpeg/src/core/device/macos_avfoundation.rs
+++ b/crates/ez-ffmpeg/src/core/device/macos_avfoundation.rs
@@ -11,11 +11,9 @@ use objc::sel_impl;
 
 pub fn get_avfoundation_devices(media_type: &str) -> crate::error::Result<Vec<String>> {
     let option = Class::get("AVCaptureDevice");
-    if let None = option {
+    let Some(av_capture_device_class) = option else {
         return Err(AVCaptureDeviceNotFound.into());
-    }
-
-    let av_capture_device_class = option.unwrap();
+    };
 
     // Convert media type to CFString
     let media_type_cf = CFString::new(media_type);

--- a/crates/test-server/src/lib.rs
+++ b/crates/test-server/src/lib.rs
@@ -46,10 +46,24 @@ impl TestServer {
             .await
     }
 
+    /// Start an unshared server instance with a custom config mutator.
+    ///
+    /// This is intended for optional tests (e.g. S3/MinIO) that need a different backend.
+    pub async fn start_with_config(mutate: impl FnOnce(&mut Config)) -> Self {
+        Self::start_with_webhook_and_config("", mutate).await
+    }
+
     /// Start the server with webhook URL (private)
     async fn start_with_webhook(webhook_url: &str) -> Self {
-        // Only open when debugging
-        tracing_subscriber::fmt::init();
+        Self::start_with_webhook_and_config(webhook_url, |_| {}).await
+    }
+
+    async fn start_with_webhook_and_config(
+        webhook_url: &str,
+        mutate: impl FnOnce(&mut Config),
+    ) -> Self {
+        // Only open when debugging; don't panic if already initialized by other tests.
+        _ = tracing_subscriber::fmt::try_init();
 
         // Initialize ffmpeg once
         static FFMPEG_INIT: std::sync::Once = std::sync::Once::new();
@@ -71,7 +85,7 @@ impl TestServer {
         // Clean up existing workspace
         let _ = tokio::fs::remove_dir_all(&workspace).await;
 
-        let config = Config {
+        let mut config = Config {
             listen_on_port: e_port,
             internal_port: i_port,
             workspace: workspace.clone(),
@@ -82,6 +96,8 @@ impl TestServer {
             },
             ..Default::default()
         };
+
+        mutate(&mut config);
 
         // Spawn the server in a separate thread with its own runtime
         let handle = std::thread::spawn(move || {

--- a/docs/api-zh.md
+++ b/docs/api-zh.md
@@ -106,6 +106,9 @@ curl -X POST http://localhost:32146/claims \
 |-----|------|-----|------|------|
 | id | string | 是 | 任务ID | 不能包含 '/', '-', '.', ' ' |
 | crf | u8 | 是 | 视频压缩质量参数 | 0-63，值越小质量越高 |
+| dst_bucket | string | 否* | 目标桶（S3 模式下 HLS 产物会上传到该桶） | 不能为空、不能包含 `/`、不允许纯数字 |
+
+> \* 当 `storage_backend = "s3"` 时，`dst_bucket` 为必填；当 `storage_backend = "local"` 时会被忽略。
 
 #### 请求体
 
@@ -142,6 +145,11 @@ curl -X POST http://localhost:32146/claims \
 ```bash
 # 上传视频文件进行转换，CRF=23（适中质量）
 curl -X POST "http://localhost:32146/upload?id=video123&crf=23" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary @input.mp4
+
+# S3 模式：需要指定 dst_bucket
+curl -X POST "http://localhost:32146/upload?id=video123&crf=23&dst_bucket=my-bucket" \
   -H "Content-Type: application/octet-stream" \
   --data-binary @input.mp4
 ```
@@ -184,29 +192,99 @@ curl -g -X POST "http://localhost:32146/upload?id=video2&crf=38&codecs[0]=h265" 
 curl http://localhost:32146/waitlist
 ```
 
+### 4. 迁移视频文件到新桶 (Migrate)
+
+将指定 `job_id` 对应的 HLS 产物从 `src_bucket` 迁移到 `dst_bucket`。
+
+**接口地址**: `POST /migrate`
+**认证要求**: 无（仅内部 API）
+**后端要求**: 仅当 `storage_backend = "s3"` 时可用
+
+> 注意：当前版本迁移完成后**不会删除源桶对象**（为安全起见暂时禁用删除）。
+
+#### 请求参数 (JSON Body)
+
+| 参数 | 类型 | 必填 | 说明 |
+|-----|------|-----|------|
+| job_id | string | 是 | 任务ID（同 `/upload?id=...`） |
+| src_bucket | string | 是 | 源桶 |
+| dst_bucket | string | 是 | 目标桶 |
+| widths | Vec<u16> | 否 | 需要迁移的清晰度宽度列表；不传则使用服务内置默认分辨率列表 |
+| dry_run | bool | 否 | 是否只统计不执行复制；默认 false |
+
+Bucket 限制：
+- 不能为空
+- 不能包含 `/`
+- 不允许为纯数字（例如 `123`），以避免与清晰度路径（如 `720/...`）产生歧义
+
+#### 响应格式
+
+成功响应 (200 OK):
+```json
+{
+  "job_id": "video123",
+  "src_bucket": "old-bucket",
+  "dst_bucket": "new-bucket",
+  "dry_run": false,
+  "objects_total": 4,
+  "objects_copied": 4,
+  "bytes_copied": 12345
+}
+```
+
+错误响应：
+
+- 400 Bad Request:
+```json
+{ "job_id": "video123", "message": "错误信息" }
+```
+
+- 500 Internal Server Error:
+```json
+{ "job_id": "video123", "message": "错误信息" }
+```
+
+#### CURL 示例
+
+```bash
+curl -X POST http://localhost:32146/migrate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "job_id": "video123",
+    "src_bucket": "old-bucket",
+    "dst_bucket": "new-bucket",
+    "widths": [480],
+    "dry_run": false
+  }'
+```
+
 ## 外部 API 接口
 
 外部 API 默认监听在 `0.0.0.0:32145`
 
-### 4. 获取视频文件
+### 5. 获取视频文件
 
 获取转换后的视频文件（HLS 格式）。
 
-**接口地址**: `GET /videos/{filename}`
+**接口地址**: `GET /videos/{bucket}/{key}`
 **认证要求**: 需要有效的 claim 令牌
-**S3 模式要求**: 需要使用 `GET /videos/{bucket}/{key}`（bucket 由上层服务决定）
+
+> 说明：
+> - 在 `storage_backend = "s3"` 时，必须显式带上 `bucket`，服务会按 bucket 读取对象存储。
+> - 在 `storage_backend = "local"` 时，`bucket` 会被忽略（但建议统一带上，便于未来切换到 S3）。
 
 #### 路径参数
 
 | 参数 | 类型 | 必填 | 说明 |
 |-----|------|-----|------|
-| filename | string | 是 | 视频文件名，格式通常为 `{job_id}-{resolution}.m3u8` 或 `{job_id}-{resolution}-{segment}.ts` |
+| bucket | string | 是 | 桶名（由上层服务决定） |
+| key | string | 是 | 桶内对象 key。典型示例：`{job_id}.m3u8`、`480/{job_id}.m3u8`、`480/{job_id}-001.m4s`、`480/{job_id}-init.mp4` |
 
 #### 请求头
 
 | 头部 | 必填 | 说明 |
 |------|-----|------|
-| X-Claim-Token | 是 | 认证令牌 |
+| Authorization | 是 | `Bearer <token>` |
 | Range | 否 | 支持范围请求，格式: `bytes=start-end` |
 
 #### 响应格式
@@ -214,7 +292,8 @@ curl http://localhost:32146/waitlist
 成功响应 (200 OK 或 206 Partial Content):
 - Content-Type: 根据文件类型自动判断
   - .m3u8 文件: application/vnd.apple.mpegurl
-  - .ts 文件: video/mp2t
+  - .m4s 文件: video/iso.segment
+  - .mp4 文件: video/mp4
 - Accept-Ranges: bytes
 - Cache-Control: public,max-age=3600
 - Content-Length: 文件大小或范围大小
@@ -232,16 +311,16 @@ curl http://localhost:32146/waitlist
 ```bash
 # 获取 HLS 播放列表
 curl -H "Authorization: Bearer your_token_here" \
-  http://localhost:32145/videos/my-bucket/video123-1080.m3u8
+  http://localhost:32145/videos/my-bucket/video123.m3u8
 
 # 获取视频片段
 curl -H "Authorization: Bearer your_token_here" \
-  http://localhost:32145/videos/my-bucket/video123-1080-00001.ts
+  http://localhost:32145/videos/my-bucket/480/video123-001.m4s
 
 # 使用范围请求
 curl -H "Authorization: Bearer your_token_here" \
   -H "Range: bytes=0-1048575" \
-  http://localhost:32145/videos/my-bucket/video123-1080-00001.ts
+  http://localhost:32145/videos/my-bucket/480/video123-001.m4s
 ```
 
 ## 速率限制
@@ -351,14 +430,21 @@ curl -X POST http://localhost:32146/claims \
 ```bash
 # 假设返回的令牌为 TOKEN
 TOKEN="your_token_here"
+BUCKET="my-bucket"
 
 # 获取 HLS 主播放列表
 curl -H "Authorization: Bearer $TOKEN" \
-  http://localhost:32145/videos/1080/myvideo.m3u8 > playlist.m3u8
+  http://localhost:32145/videos/$BUCKET/myvideo.m3u8 > playlist.m3u8
 
-# 获取视频片段
+# 获取某个清晰度的播放列表（例如 480p）
 curl -H "Authorization: Bearer $TOKEN" \
-  http://localhost:32145/videos/1080/myvideo-00001.ts > segment1.ts
+  http://localhost:32145/videos/$BUCKET/480/myvideo.m3u8 > playlist-480.m3u8
+
+# 获取 init segment / media segment
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:32145/videos/$BUCKET/480/myvideo-init.mp4 > init.mp4
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:32145/videos/$BUCKET/480/myvideo-001.m4s > segment1.m4s
 ```
 
 #### 获取h265视频片段
@@ -366,14 +452,15 @@ curl -H "Authorization: Bearer $TOKEN" \
 ```bash
 # 假设返回的令牌为 TOKEN
 TOKEN="your_token_here"
+BUCKET="my-bucket"
 
 # 获取 HLS 主播放列表
 curl -H "Authorization: Bearer $TOKEN" \
-  http://localhost:32145/videos/1080/myvideo-h265.m3u8 > h265-playlist.m3u8
+  http://localhost:32145/videos/$BUCKET/myvideo-h265.m3u8 > h265-playlist.m3u8
 
-# 获取h265视频片段
+# 获取h265视频片段（例如 480p）
 curl -H "Authorization: Bearer $TOKEN" \
-  http://localhost:32145/videos/1080/myvideo-h265-00001.ts > h265-segment1.ts
+  http://localhost:32145/videos/$BUCKET/480/myvideo-h265-001.m4s > h265-segment1.m4s
 ```
 
 ## 配置说明
@@ -411,6 +498,7 @@ s3_secret_access_key = "minioadmin"
 当使用 `storage_backend = "s3"` 时，bucket 由上层服务在请求/任务参数中指定：
 - 上传/转码：`POST /upload?...&dst_bucket=<bucket>`
 - 播放读取：`GET /videos/<bucket>/<key>`
+- 迁移对象：`POST /migrate {src_bucket, dst_bucket, job_id, ...}`
 - 注意：`dst_bucket` 不允许为纯数字（例如 `123`），以避免与清晰度路径（如 `720/...`）产生歧义。
 
 ### 认证密钥配置

--- a/docs/api-zh.md
+++ b/docs/api-zh.md
@@ -194,6 +194,7 @@ curl http://localhost:32146/waitlist
 
 **接口地址**: `GET /videos/{filename}`
 **认证要求**: 需要有效的 claim 令牌
+**S3 模式要求**: 需要使用 `GET /videos/{bucket}/{key}`（bucket 由上层服务决定）
 
 #### 路径参数
 
@@ -231,16 +232,16 @@ curl http://localhost:32146/waitlist
 ```bash
 # 获取 HLS 播放列表
 curl -H "Authorization: Bearer your_token_here" \
-  http://localhost:32145/videos/video123-1080.m3u8
+  http://localhost:32145/videos/my-bucket/video123-1080.m3u8
 
 # 获取视频片段
 curl -H "Authorization: Bearer your_token_here" \
-  http://localhost:32145/videos/video123-1080-00001.ts
+  http://localhost:32145/videos/my-bucket/video123-1080-00001.ts
 
 # 使用范围请求
 curl -H "Authorization: Bearer your_token_here" \
   -H "Range: bytes=0-1048575" \
-  http://localhost:32145/videos/video123-1080-00001.ts
+  http://localhost:32145/videos/my-bucket/video123-1080-00001.ts
 ```
 
 ## 速率限制
@@ -401,12 +402,16 @@ workspace = "./data"
 
 # S3 存储
 storage_backend = "s3"
-s3_bucket = "my-video-bucket"
 s3_endpoint = "http://localhost:9000"  # MinIO 或自定义 S3
 s3_region = "us-east-1"
 s3_access_key_id = "minioadmin"
 s3_secret_access_key = "minioadmin"
 ```
+
+当使用 `storage_backend = "s3"` 时，bucket 由上层服务在请求/任务参数中指定：
+- 上传/转码：`POST /upload?...&dst_bucket=<bucket>`
+- 播放读取：`GET /videos/<bucket>/<key>`
+- 注意：`dst_bucket` 不允许为纯数字（例如 `123`），以避免与清晰度路径（如 `720/...`）产生歧义。
 
 ### 认证密钥配置
 

--- a/docs/claim-zh.md
+++ b/docs/claim-zh.md
@@ -15,7 +15,7 @@ sequenceDiagram
     Up->>VS: POST /claims {assets, window, limits}
     VS-->>Up: {token_b64url}
     Up-->>P: 下发 token
-    P->>VS: GET /videos/<asset>-xxx.m4s + Authorization: Bearer <token>
+    P->>VS: GET /videos/<bucket>/<asset>-xxx.m4s + Authorization: Bearer <token>
     VS->>VS: 解码→解密→校验→限速
     VS-->>P: 200/401/403
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -195,6 +195,29 @@ In S3 mode, the target bucket is selected per request/job:
 - Playback: `GET /videos/video-storage/<key>`
 - Note: `dst_bucket` must not be numeric-only (e.g. `123`).
 
+### S3/MinIO 集成测试（本地默认不跑）
+
+仓库里有一条真正连 MinIO 的 S3 集成测试：`crates/core/tests/s3_optional_integration_test.rs`。
+
+- 本地默认不执行（测试带 `#[ignore]`）
+- CI 会显式用 `--ignored` 跑它
+
+手动运行示例：
+
+1) 启动 MinIO，并创建两个桶（示例：`vs-test-src` / `vs-test-dst`）。
+
+2) 运行测试：
+
+```bash
+VS_TEST_S3_ENDPOINT=http://127.0.0.1:9000 \
+VS_TEST_S3_REGION=us-east-1 \
+VS_TEST_S3_ACCESS_KEY_ID=minioadmin \
+VS_TEST_S3_SECRET_ACCESS_KEY=minioadmin \
+VS_TEST_S3_SRC_BUCKET=vs-test-src \
+VS_TEST_S3_DST_BUCKET=vs-test-dst \
+cargo test -p video-storage-core --test s3_optional_integration_test -- --ignored
+```
+
 ## Common Issues
 
 ### FFmpeg Build Errors

--- a/docs/development.md
+++ b/docs/development.md
@@ -184,12 +184,16 @@ Then run the service:
 ```bash
 cargo run -- \
   --storage-backend s3 \
-  --s3-bucket video-storage \
   --s3-endpoint http://localhost:9000 \
   --s3-region us-east-1 \
   --s3-access-key-id minioadmin \
   --s3-secret-access-key minioadmin
 ```
+
+In S3 mode, the target bucket is selected per request/job:
+- Upload/convert: `POST /upload?...&dst_bucket=video-storage`
+- Playback: `GET /videos/video-storage/<key>`
+- Note: `dst_bucket` must not be numeric-only (e.g. `123`).
 
 ## Common Issues
 


### PR DESCRIPTION
1. 提供迁移文件到新桶: src, dst, job-id // 迁移后 //删除源文件
2. server-video时, bucket加到path里
3. 创建切片时, 添加目标bucket, 切片完成后写入给定桶.
4. 启动参数只移除s3_bucket, 其他的复用
5. 管理s3_bucket, 复用同样的桶参数创建