### PR TITLE
feat: migrate /migrate to async job execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ When `storage_backend = "s3"`, the bucket is selected per request/job:
 - Upload/convert: pass `dst_bucket` in the `/upload` query string (e.g. `/upload?...&dst_bucket=my-bucket`)
 - Playback: request via `/videos/<bucket>/<key>` (e.g. `/videos/my-bucket/720/<job_id>.m3u8`)
 - Optional compatibility: set `--s3-bucket` (or `S3_BUCKET`) to allow legacy reads via `/videos/<key>` and `/videos/<width>/<key>` (defaults to that bucket)
-- Migrate between buckets (internal API): `POST /migrate {src_bucket, dst_bucket, job_id, ...}`
+- Migrate between buckets (internal API): `POST /migrate {src_bucket, dst_bucket, job_id, ...}` returns `202 Accepted` and runs in the background
 - Note: `dst_bucket` must not be numeric-only (e.g. `123`).
 
 ### Using configuration file
@@ -198,6 +198,7 @@ listen_on_port = 32145
 internal_port = 32146
 permits = 10
 # Minimum permits is 10 to accommodate codec/scale concurrency and uploads
+migrate_permits = 1
 token_rate = 0.0
 workspace = "./data"
 
@@ -232,7 +233,7 @@ Webhook payload format:
 ```json
 {
   "job_id": "video",
-  "job_type": "convert",  // or "upload"
+  "job_type": "convert",  // or "upload" / "migrate"
   "status": "completed",
   "timestamp": "2025-01-09T12:34:56Z"
 }
@@ -253,8 +254,9 @@ response:
 ```json
 {
   "pending_convert_jobs": 2,
+  "pending_migrate_jobs": 1,
   "pending_upload_jobs": 1,
-  "total_pending_jobs": 3
+  "total_pending_jobs": 4
 }
 ```
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -5,6 +5,7 @@
 listen_on_port = 32145            # Port to listen on
 internal_port = 32146              # Internal API port to listen on
 permits = 10                      # Number of concurrent conversion jobs (minimum required)
+migrate_permits = 1               # Number of concurrent migration jobs
 token_rate = 0.0                  # Token bucket rate limiting (0.0 = disabled)
 workspace = "./data"              # Working directory for file storage
 
@@ -21,7 +22,7 @@ storage_backend = "local"         # Storage backend: "local" or "s3"
 
 # Note (S3 mode):
 # - Bucket is selected per request/job (e.g. /upload?...&dst_bucket=... and /videos/<bucket>/<key>)
-# - Internal migration endpoint is available: POST /migrate {src_bucket, dst_bucket, job_id, ...}
+# - Internal migration endpoint is available: POST /migrate {src_bucket, dst_bucket, job_id, ...} (async, returns 202)
 
 # Webhook configuration (optional)
 # Uncomment to enable webhook notifications when jobs complete

--- a/crates/core/src/api/routes.rs
+++ b/crates/core/src/api/routes.rs
@@ -1,4 +1,4 @@
-use crate::job::{CONVERT_KIND, UPLOAD_KIND};
+use crate::job::{CONVERT_KIND, MIGRATE_KIND, MigrateJob, UPLOAD_KIND};
 use crate::{AppState, ConvertJob, Job};
 use axum::body::Body;
 use axum::extract::{Extension, Path as AxumPath};
@@ -6,18 +6,14 @@ use axum::http::{HeaderValue, Request, Response, StatusCode, header};
 use axum::response::{IntoResponse, Json};
 use bytes::Bytes;
 use futures::StreamExt;
-use opendal::EntryMode;
 use opendal::Operator;
-use opendal::options;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
 use std::convert::Infallible;
 use std::ffi::OsStr;
 use std::io::Error as IoError;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::io::AsyncSeekExt;
-use tokio_util::compat::{FuturesAsyncReadCompatExt as _, FuturesAsyncWriteCompatExt as _};
 use tokio_util::io::ReaderStream;
 use tracing::{debug, error, info, warn};
 use video_storage_claim::create_request::AssetsFilter;
@@ -35,18 +31,14 @@ pub struct UploadResponse {
 pub struct WaitlistResponse {
     pub pending_convert_jobs: usize,
     pub pending_upload_jobs: usize,
+    pub pending_migrate_jobs: usize,
     pub total_pending_jobs: usize,
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct MigrateResponse {
+pub struct MigrateAcceptedResponse {
     pub job_id: String,
-    pub src_bucket: String,
-    pub dst_bucket: String,
-    pub dry_run: bool,
-    pub objects_total: u64,
-    pub objects_copied: u64,
-    pub bytes_copied: u64,
+    pub message: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -56,8 +48,6 @@ pub struct MigrateRequest {
     pub dst_bucket: String,
     #[serde(default)]
     pub widths: Option<Vec<u16>>,
-    #[serde(default)]
-    pub dry_run: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -84,13 +74,15 @@ pub async fn waitlist(Extension(state): Extension<AppState>) -> impl IntoRespons
 
     let convert_jobs = jobs.iter().filter(|&&kind| kind == CONVERT_KIND).count();
     let upload_jobs = jobs.iter().filter(|&&kind| kind == UPLOAD_KIND).count();
+    let migrate_jobs = jobs.iter().filter(|&&kind| kind == MIGRATE_KIND).count();
 
     (
         StatusCode::OK,
         Json(WaitlistResponse {
             pending_convert_jobs: convert_jobs,
             pending_upload_jobs: upload_jobs,
-            total_pending_jobs: convert_jobs + upload_jobs,
+            pending_migrate_jobs: migrate_jobs,
+            total_pending_jobs: convert_jobs + upload_jobs + migrate_jobs,
         }),
     )
 }
@@ -148,7 +140,7 @@ pub async fn upload_mp4_raw(
         );
     }
 
-    if !is_valid_job_id(&job_id) {
+    if !is_valid_job_id(job_id.as_str()) {
         return (
             StatusCode::BAD_REQUEST,
             Json(UploadResponse {
@@ -158,14 +150,10 @@ pub async fn upload_mp4_raw(
         );
     }
 
-    if state
-        .jobs_manager
-        .jobs
-        .lock()
-        .await
-        .iter()
-        .any(|j| j.id() == job.id())
-    {
+    let jobs = state.jobs_manager.jobs.lock().await;
+    let already_exists = jobs.iter().any(|existing| existing.id() == job.id());
+    drop(jobs);
+    if already_exists {
         return (
             StatusCode::BAD_REQUEST,
             Json(UploadResponse {
@@ -507,13 +495,13 @@ pub async fn migrate_videos(
     Extension(state): Extension<AppState>,
     Json(request): Json<MigrateRequest>,
 ) -> impl IntoResponse {
-    let job_id = request.job_id.clone();
+    let job_id = request.job_id.as_str();
 
     let migrate_err = |status: StatusCode, message: String| {
         (
             status,
             Json(MigrateErrorResponse {
-                job_id: job_id.clone(),
+                job_id: job_id.to_string(),
                 message,
             }),
         )
@@ -524,7 +512,7 @@ pub async fn migrate_videos(
         return migrate_err(StatusCode::BAD_REQUEST, "storage_backend is not s3".into());
     }
 
-    if !is_valid_job_id(&job_id) {
+    if !is_valid_job_id(job_id) {
         return migrate_err(StatusCode::BAD_REQUEST, "Invalid job ID format".into());
     }
 
@@ -541,170 +529,53 @@ pub async fn migrate_videos(
         );
     }
 
-    let src_op = match state
+    let jobs = state.jobs_manager.jobs.lock().await;
+    let already_exists = jobs.iter().any(|existing| existing.id() == job_id);
+    drop(jobs);
+
+    if already_exists {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(UploadResponse {
+                job_id: job_id.to_string(),
+                message: "Migration already in-progress".into(),
+            }),
+        )
+            .into_response();
+    }
+
+    if let Err(error) = state
         .storage_manager
         .operator_for_bucket(&request.src_bucket)
     {
-        Ok(op) => op,
-        Err(error) => {
-            warn!(?error, bucket = %request.src_bucket, "Invalid src_bucket");
-            return migrate_err(StatusCode::BAD_REQUEST, "Invalid src_bucket".into());
-        }
-    };
-    let dst_op = match state
+        warn!(?error, bucket = %request.src_bucket, "Invalid src_bucket");
+        return migrate_err(StatusCode::BAD_REQUEST, "Invalid src_bucket".into());
+    }
+    if let Err(error) = state
         .storage_manager
         .operator_for_bucket(&request.dst_bucket)
     {
-        Ok(op) => op,
-        Err(error) => {
-            warn!(?error, bucket = %request.dst_bucket, "Invalid dst_bucket");
-            return migrate_err(StatusCode::BAD_REQUEST, "Invalid dst_bucket".into());
-        }
-    };
-
-    let widths = request.widths.unwrap_or_else(|| {
-        crate::job::convert::RESOLUTIONS
-            .iter()
-            .map(|s| u16::try_from(s.width()).expect("resolution width must fit in u16"))
-            .collect()
-    });
-    let mut prefixes = Vec::with_capacity(widths.len() + 1);
-    prefixes.push(format!("videos/{job_id}"));
-    for w in widths {
-        prefixes.push(format!("videos/{w}/{job_id}"));
+        warn!(?error, bucket = %request.dst_bucket, "Invalid dst_bucket");
+        return migrate_err(StatusCode::BAD_REQUEST, "Invalid dst_bucket".into());
     }
 
-    let mut keys: BTreeSet<String> = BTreeSet::new();
-    for prefix in prefixes {
-        let mut lister = match src_op
-            .lister_options(
-                &prefix,
-                options::ListOptions {
-                    recursive: true,
-                    ..Default::default()
-                },
-            )
-            .await
-        {
-            Ok(lister) => lister,
-            Err(error) => {
-                error!(?error, %prefix, "Failed to list src objects");
-                return migrate_err(StatusCode::INTERNAL_SERVER_ERROR, "List failed".into());
-            }
-        };
-
-        use futures::TryStreamExt as _;
-        while let Some(entry) = match lister.try_next().await {
-            Ok(v) => v,
-            Err(error) => {
-                error!(?error, %prefix, "Failed to iterate src objects");
-                return migrate_err(StatusCode::INTERNAL_SERVER_ERROR, "List failed".into());
-            }
-        } {
-            if entry.metadata().mode() != EntryMode::FILE {
-                continue;
-            }
-            let path = entry.path();
-            let Some(rest) = path.strip_prefix(&prefix) else {
-                continue;
-            };
-            if !(rest.starts_with('.') || rest.starts_with('-')) {
-                continue;
-            }
-            _ = keys.insert(path.to_string());
-        }
-    }
-
-    let mut objects_total = 0u64;
-    let mut objects_copied = 0u64;
-    let mut bytes_copied = 0u64;
-
-    const DELETE_SOURCE_OBJECTS: bool = false;
-
-    for key in keys {
-        objects_total += 1;
-
-        let meta = match src_op.stat(&key).await {
-            Ok(m) => m,
-            Err(error) => {
-                error!(?error, %key, "Failed to stat src object");
-                return migrate_err(StatusCode::INTERNAL_SERVER_ERROR, "Stat failed".into());
-            }
-        };
-
-        let size = meta.content_length();
-        if request.dry_run {
-            bytes_copied += size;
-            objects_copied += 1;
-            continue;
-        }
-
-        let copied = match copy_object_streaming(&src_op, &dst_op, &key, meta.content_type()).await
-        {
-            Ok(v) => v,
-            Err(error) => {
-                error!(?error, %key, "Failed to copy object");
-                return migrate_err(StatusCode::INTERNAL_SERVER_ERROR, "Copy failed".into());
-            }
-        };
-
-        bytes_copied += copied;
-        objects_copied += 1;
-
-        // NOTE: Deletion is intentionally disabled in this release to prevent accidental data loss.
-        if DELETE_SOURCE_OBJECTS && let Err(error) = src_op.delete(&key).await {
-            error!(?error, %key, "Failed to delete src object");
-            return migrate_err(StatusCode::INTERNAL_SERVER_ERROR, "Delete failed".into());
-        }
-    }
+    let job = MigrateJob::new(
+        request.job_id.clone(),
+        request.src_bucket,
+        request.dst_bucket,
+        MigrateJob::resolved_widths(request.widths),
+    );
+    state.jobs_manager.add(&job).await;
+    _ = state.job_tx.unbounded_send(job.into());
 
     (
-        StatusCode::OK,
-        Json(MigrateResponse {
-            job_id,
-            src_bucket: request.src_bucket,
-            dst_bucket: request.dst_bucket,
-            dry_run: request.dry_run,
-            objects_total,
-            objects_copied,
-            bytes_copied,
+        StatusCode::ACCEPTED,
+        Json(MigrateAcceptedResponse {
+            job_id: job_id.to_string(),
+            message: "Processing in background".into(),
         }),
     )
         .into_response()
-}
-
-async fn copy_object_streaming(
-    src: &Operator,
-    dst: &Operator,
-    key: &str,
-    content_type: Option<&str>,
-) -> anyhow::Result<u64> {
-    const MIGRATE_STREAM_CONCURRENCY: usize = 1;
-    const MIGRATE_STREAM_CHUNK_SIZE: usize = 8 * 1024 * 1024;
-
-    // Migrate against the source bucket in a single stream to avoid amplifying
-    // load with multipart read/write concurrency when the bucket is already hot.
-    let reader = src
-        .reader_with(key)
-        .chunk(MIGRATE_STREAM_CHUNK_SIZE)
-        .concurrent(MIGRATE_STREAM_CONCURRENCY)
-        .await?;
-    let mut r = reader.into_futures_async_read(..).await?.compat();
-
-    let mut writer = dst
-        .writer_with(key)
-        .chunk(MIGRATE_STREAM_CHUNK_SIZE)
-        .concurrent(MIGRATE_STREAM_CONCURRENCY);
-    if let Some(ct) = content_type {
-        writer = writer.content_type(ct);
-    }
-    let mut w = writer.await?.into_futures_async_write().compat_write();
-
-    let copied = tokio::io::copy(&mut r, &mut w).await?;
-    use tokio::io::AsyncWriteExt as _;
-    w.shutdown().await?;
-
-    Ok(copied)
 }
 
 /// Create a new claim token for video access
@@ -1004,7 +875,7 @@ mod tests {
         .unwrap();
 
         // Use zero permits so background worker never starts processing the job during the test
-        let state = AppState::new(0, temp_dir.path(), storage_manager, None, Vec::new())
+        let state = AppState::new(0, 1, temp_dir.path(), storage_manager, None, Vec::new())
             .await
             .unwrap();
 
@@ -1034,7 +905,7 @@ mod tests {
             .iter()
             .find_map(|job| {
                 if job.id() == job_id {
-                    Some(job.to_json())
+                    Some(job.payload_json())
                 } else {
                     None
                 }
@@ -1145,7 +1016,7 @@ mod tests {
         .await
         .unwrap();
 
-        let state = AppState::new(0, temp_dir.path(), storage_manager, None, Vec::new())
+        let state = AppState::new(0, 1, temp_dir.path(), storage_manager, None, Vec::new())
             .await
             .unwrap();
 
@@ -1190,7 +1061,7 @@ mod tests {
         .await
         .unwrap();
 
-        let state = AppState::new(0, temp_dir.path(), storage_manager, None, Vec::new())
+        let state = AppState::new(0, 1, temp_dir.path(), storage_manager, None, Vec::new())
             .await
             .unwrap();
 
@@ -1227,7 +1098,7 @@ mod tests {
         .await
         .unwrap();
 
-        let state = AppState::new(0, temp_dir.path(), storage_manager, None, Vec::new())
+        let state = AppState::new(0, 1, temp_dir.path(), storage_manager, None, Vec::new())
             .await
             .unwrap();
 
@@ -1235,7 +1106,6 @@ mod tests {
             src_bucket: "src".into(),
             dst_bucket: "dst".into(),
             job_id: "test123".into(),
-            dry_run: true,
             widths: None,
         };
 
@@ -1271,7 +1141,7 @@ mod tests {
         .await
         .unwrap();
 
-        let state = AppState::new(0, temp_dir.path(), storage_manager, None, Vec::new())
+        let state = AppState::new(0, 1, temp_dir.path(), storage_manager, None, Vec::new())
             .await
             .unwrap();
 
@@ -1279,7 +1149,6 @@ mod tests {
             src_bucket: "123".into(),
             dst_bucket: "dst".into(),
             job_id: "test123".into(),
-            dry_run: true,
             widths: None,
         };
 
@@ -1294,5 +1163,51 @@ mod tests {
         let err: MigrateErrorResponse = serde_json::from_slice(&body_bytes).unwrap();
         assert_eq!(err.job_id, "test123");
         assert!(err.message.contains("numeric-only"));
+    }
+
+    #[tokio::test]
+    async fn test_migrate_videos_rejects_duplicate_pending_jobs() {
+        use crate::job::MigrateJob;
+        use crate::opendal::{StorageBackend, StorageConfig, StorageManager};
+        use tempfile::tempdir;
+
+        let temp_dir = tempdir().unwrap();
+        let storage_manager = StorageManager::new(StorageConfig {
+            backend: StorageBackend::S3 {
+                endpoint: Some("http://127.0.0.1:9000".into()),
+                region: Some("us-east-1".into()),
+                default_bucket: None,
+                access_key_id: "minioadmin".into(),
+                secret_access_key: "minioadmin".into(),
+            },
+            workspace: temp_dir.path().to_path_buf(),
+        })
+        .await
+        .unwrap();
+
+        let state = AppState::new(0, 1, temp_dir.path(), storage_manager, None, Vec::new())
+            .await
+            .unwrap();
+        let existing_job = MigrateJob::new("test123".into(), "src".into(), "dst".into(), vec![480]);
+        state.jobs_manager.add(&existing_job).await;
+
+        let request = MigrateRequest {
+            src_bucket: "src".into(),
+            dst_bucket: "dst".into(),
+            job_id: "test123".into(),
+            widths: Some(vec![480]),
+        };
+
+        let response = migrate_videos(Extension(state), Json(request))
+            .await
+            .into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let response: UploadResponse = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(response.job_id, "test123");
+        assert!(response.message.contains("in-progress"));
     }
 }

--- a/crates/core/src/app_state.rs
+++ b/crates/core/src/app_state.rs
@@ -30,6 +30,7 @@ pub struct AppState {
     pub claim_manager: ClaimManager,
     pub storage_manager: Arc<StorageManager>,
     pub permits: usize,
+    pub migrate_permits: usize,
 
     pub temp_dir: PathBuf,
     pub videos_dir: PathBuf,
@@ -40,6 +41,7 @@ pub struct AppState {
 impl AppState {
     pub async fn new(
         permits: usize,
+        migrate_permits: usize,
         workspace: &Path,
         storage_manager: StorageManager,
         webhook_url: Option<String>,
@@ -60,6 +62,7 @@ impl AppState {
             claim_manager,
             storage_manager: Arc::new(storage_manager),
             permits,
+            migrate_permits,
 
             temp_dir: workspace.join(TEMP_DIR),
             uploads_dir: workspace.join(UPLOADS_DIR),
@@ -71,7 +74,7 @@ impl AppState {
         this.claim_manager.start_cleanup_task();
 
         // Start job handler
-        this.start_job_handler(rx, permits);
+        this.start_job_handler(rx, permits, migrate_permits);
 
         Ok(this)
     }
@@ -124,12 +127,18 @@ impl AppState {
         }
     }
 
-    fn start_job_handler(&self, rx: UnboundedReceiver<RawJob>, permits: usize) {
-        info!(permits, "Job handler started");
+    fn start_job_handler(
+        &self,
+        rx: UnboundedReceiver<RawJob>,
+        permits: usize,
+        migrate_permits: usize,
+    ) {
+        info!(permits, migrate_permits, "Job handler started");
         let this = self.clone();
         let semaphores = JobSemaphores::new(
             Arc::new(Semaphore::new(permits)),
             Arc::new(Semaphore::new(1)),
+            Arc::new(Semaphore::new(migrate_permits)),
         );
 
         tokio::spawn(async move {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -15,6 +15,7 @@ use std::path::Path;
 /// listen_on_port = 32145
 /// internal_port = 32146
 /// permits = 10
+/// migrate_permits = 1
 /// token_rate = 0.0
 /// workspace = "./data"
 ///
@@ -48,6 +49,11 @@ pub struct Config {
     #[arg(short, long, default_value_t = MIN_PERMITS)]
     #[serde(default = "default_permits")]
     pub permits: usize,
+
+    /// Number of concurrent migration jobs
+    #[arg(long, default_value_t = default_migrate_permits())]
+    #[serde(default = "default_migrate_permits")]
+    pub migrate_permits: usize,
 
     /// (Deprecated): Token bucket rate limiting (0.0 = disabled)
     #[arg(short, long, default_value_t = 0.0)]
@@ -186,6 +192,7 @@ impl Default for Config {
             listen_on_port: default_port(),
             internal_port: default_internal_port(),
             permits: default_permits(),
+            migrate_permits: default_migrate_permits(),
             token_rate: default_token_rate(),
             workspace: default_workspace(),
             config: None,
@@ -249,6 +256,9 @@ impl Config {
         }
         if self.permits == default_permits() {
             self.permits = file_config.permits;
+        }
+        if self.migrate_permits == default_migrate_permits() {
+            self.migrate_permits = file_config.migrate_permits;
         }
         if self.token_rate == default_token_rate() {
             self.token_rate = file_config.token_rate;
@@ -350,6 +360,10 @@ impl Config {
             }
         }
 
+        if self.migrate_permits == 0 {
+            return Err(anyhow::anyhow!("migrate_permits must be greater than 0"));
+        }
+
         Ok(())
     }
 
@@ -395,6 +409,10 @@ const MIN_PERMITS: usize = 10;
 
 fn default_permits() -> usize {
     MIN_PERMITS
+}
+
+fn default_migrate_permits() -> usize {
+    1
 }
 
 fn default_token_rate() -> f64 {

--- a/crates/core/src/job/migrate.rs
+++ b/crates/core/src/job/migrate.rs
@@ -1,0 +1,284 @@
+use crate::app_state::AppState;
+use crate::job::convert::RESOLUTIONS;
+use crate::job::{FailureJob, Job, JobKind, MIGRATE_KIND};
+use anyhow::{Context, Result};
+use futures::TryStreamExt as _;
+use opendal::EntryMode;
+use opendal::Operator;
+use opendal::options;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::time::Duration;
+use tokio::task::JoinHandle as TokioJoinHandle;
+use tokio_util::compat::{FuturesAsyncReadCompatExt as _, FuturesAsyncWriteCompatExt as _};
+use tracing::info;
+
+const MIGRATE_STREAM_CONCURRENCY: usize = 1;
+const MIGRATE_STREAM_CHUNK_SIZE: usize = 8 * 1024 * 1024;
+const MIGRATE_PROGRESS_LOG_INTERVAL: u64 = 100;
+const MAX_RETRIES: u8 = 5;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MigrateStats {
+    pub objects_total: u64,
+    pub objects_copied: u64,
+    pub bytes_copied: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MigrateJob {
+    pub id: String,
+    pub src_bucket: String,
+    pub dst_bucket: String,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub widths: Vec<u16>,
+    #[serde(default)]
+    #[serde(skip)]
+    pub retry_times: Arc<AtomicU8>,
+}
+
+impl MigrateJob {
+    pub fn new(id: String, src_bucket: String, dst_bucket: String, widths: Vec<u16>) -> Self {
+        Self {
+            id,
+            src_bucket,
+            dst_bucket,
+            widths,
+            retry_times: Arc::new(AtomicU8::new(0)),
+        }
+    }
+
+    pub fn resolved_widths(widths: Option<Vec<u16>>) -> Vec<u16> {
+        widths.unwrap_or_else(Self::default_widths)
+    }
+
+    pub fn default_widths() -> Vec<u16> {
+        RESOLUTIONS
+            .iter()
+            .map(|scale| u16::try_from(scale.width()).expect("resolution width must fit in u16"))
+            .collect()
+    }
+
+    fn object_prefixes(&self) -> Vec<String> {
+        let mut prefixes = Vec::with_capacity(self.widths.len() + 1);
+        prefixes.push(format!("videos/{}", self.id));
+        for width in &self.widths {
+            prefixes.push(format!("videos/{width}/{}", self.id));
+        }
+        prefixes
+    }
+
+    async fn run(&self, state: &AppState) -> Result<MigrateStats> {
+        let src_op = state
+            .storage_manager
+            .operator_for_bucket(&self.src_bucket)
+            .with_context(|| format!("build source operator for bucket `{}`", self.src_bucket))?;
+        let dst_op = state
+            .storage_manager
+            .operator_for_bucket(&self.dst_bucket)
+            .with_context(|| {
+                format!(
+                    "build destination operator for bucket `{}`",
+                    self.dst_bucket
+                )
+            })?;
+
+        let keys = self.list_object_keys(&src_op).await?;
+        let object_count = u64::try_from(keys.len()).expect("object count must fit in u64");
+        info!(
+            job_id = %self.id,
+            src_bucket = %self.src_bucket,
+            dst_bucket = %self.dst_bucket,
+            object_count,
+            "Migrate source objects discovered"
+        );
+
+        let mut stats = MigrateStats {
+            objects_total: object_count,
+            ..MigrateStats::default()
+        };
+
+        for key in keys {
+            let meta = src_op.stat(&key).await.with_context(|| {
+                format!(
+                    "stat source object `{key}` after copying {}/{} objects ({} bytes)",
+                    stats.objects_copied, stats.objects_total, stats.bytes_copied
+                )
+            })?;
+            let copied = copy_object_streaming(&src_op, &dst_op, &key, meta.content_type())
+                .await
+                .with_context(|| {
+                    format!(
+                        "copy source object `{key}` after copying {}/{} objects ({} bytes)",
+                        stats.objects_copied, stats.objects_total, stats.bytes_copied
+                    )
+                })?;
+
+            stats.objects_copied += 1;
+            stats.bytes_copied += copied;
+
+            if stats.objects_copied == stats.objects_total
+                || stats
+                    .objects_copied
+                    .is_multiple_of(MIGRATE_PROGRESS_LOG_INTERVAL)
+            {
+                info!(
+                    job_id = %self.id,
+                    src_bucket = %self.src_bucket,
+                    dst_bucket = %self.dst_bucket,
+                    objects_copied = stats.objects_copied,
+                    objects_total = stats.objects_total,
+                    bytes_copied = stats.bytes_copied,
+                    "Migrate progress"
+                );
+            }
+        }
+
+        Ok(stats)
+    }
+
+    async fn list_object_keys(&self, src_op: &Operator) -> Result<BTreeSet<String>> {
+        let mut keys = BTreeSet::new();
+
+        for prefix in self.object_prefixes() {
+            let mut lister = src_op
+                .lister_options(
+                    &prefix,
+                    options::ListOptions {
+                        recursive: true,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .with_context(|| format!("list source prefix `{prefix}`"))?;
+
+            while let Some(entry) = lister
+                .try_next()
+                .await
+                .with_context(|| format!("iterate source prefix `{prefix}`"))?
+            {
+                if entry.metadata().mode() != EntryMode::FILE {
+                    continue;
+                }
+                let path = entry.path();
+                let Some(rest) = path.strip_prefix(&prefix) else {
+                    continue;
+                };
+                if !(rest.starts_with('.') || rest.starts_with('-')) {
+                    continue;
+                }
+                let _ = keys.insert(path.to_string());
+            }
+        }
+
+        Ok(keys)
+    }
+}
+
+impl Job for MigrateJob {
+    fn kind(&self) -> JobKind {
+        MIGRATE_KIND
+    }
+
+    fn need_permit(&self) -> usize {
+        1
+    }
+
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn gen_job(&self, state: AppState) -> TokioJoinHandle<anyhow::Result<()>> {
+        let job = self.clone();
+        tokio::spawn(async move {
+            let stats = job.run(&state).await.with_context(|| {
+                format!(
+                    "migrate job `{}` from `{}` to `{}` failed",
+                    job.id, job.src_bucket, job.dst_bucket
+                )
+            })?;
+
+            info!(
+                job_id = %job.id,
+                src_bucket = %job.src_bucket,
+                dst_bucket = %job.dst_bucket,
+                objects_total = stats.objects_total,
+                objects_copied = stats.objects_copied,
+                bytes_copied = stats.bytes_copied,
+                "Migrate job completed successfully"
+            );
+            state.call_webhook(&job.id, MIGRATE_KIND, "completed").await;
+
+            Ok(())
+        })
+    }
+
+    fn wait_for_retry(&self) -> Option<Duration> {
+        let retry_times = self.retry_times.load(Ordering::Acquire);
+        if retry_times < MAX_RETRIES {
+            self.retry_times.store(retry_times + 1, Ordering::Release);
+            Some(Duration::from_secs(30))
+        } else {
+            None
+        }
+    }
+
+    fn on_final_failure(&self) -> FailureJob {
+        FailureJob::new(self.id.clone(), self.kind(), Vec::new())
+    }
+}
+
+async fn copy_object_streaming(
+    src: &Operator,
+    dst: &Operator,
+    key: &str,
+    content_type: Option<&str>,
+) -> Result<u64> {
+    let reader = src
+        .reader_with(key)
+        .chunk(MIGRATE_STREAM_CHUNK_SIZE)
+        .concurrent(MIGRATE_STREAM_CONCURRENCY)
+        .await?;
+    let mut r = reader.into_futures_async_read(..).await?.compat();
+
+    let mut writer = dst
+        .writer_with(key)
+        .chunk(MIGRATE_STREAM_CHUNK_SIZE)
+        .concurrent(MIGRATE_STREAM_CONCURRENCY);
+    if let Some(content_type) = content_type {
+        writer = writer.content_type(content_type);
+    }
+    let mut w = writer.await?.into_futures_async_write().compat_write();
+
+    let copied = tokio::io::copy(&mut r, &mut w).await?;
+    use tokio::io::AsyncWriteExt as _;
+    w.shutdown().await?;
+
+    Ok(copied)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolved_widths_use_defaults_when_omitted() {
+        assert_eq!(
+            MigrateJob::resolved_widths(None),
+            MigrateJob::default_widths()
+        );
+    }
+
+    #[test]
+    fn migrate_job_retries_are_bounded() {
+        let job = MigrateJob::new("video123".into(), "src".into(), "dst".into(), vec![480]);
+
+        for _ in 0..MAX_RETRIES {
+            assert_eq!(job.wait_for_retry(), Some(Duration::from_secs(30)));
+        }
+        assert_eq!(job.wait_for_retry(), None);
+    }
+}

--- a/crates/core/src/job/mod.rs
+++ b/crates/core/src/job/mod.rs
@@ -1,5 +1,6 @@
 pub mod convert;
 pub mod manager;
+pub mod migrate;
 pub mod raw;
 pub mod upload;
 
@@ -11,27 +12,39 @@ use tracing::{debug, error, info, warn};
 
 // Re-exports for convenience
 pub use convert::ConvertJob;
+pub use migrate::MigrateJob;
 pub use raw::RawJob;
 pub use upload::UploadJob;
 
 pub type JobKind = &'static str;
 pub const UPLOAD_KIND: JobKind = "upload";
 pub const CONVERT_KIND: JobKind = "convert";
+pub const MIGRATE_KIND: JobKind = "migrate";
 
 #[derive(Clone)]
 pub struct JobSemaphores {
     convert: Arc<TokioSemaphore>,
     upload: Arc<TokioSemaphore>,
+    migrate: Arc<TokioSemaphore>,
 }
 
 impl JobSemaphores {
-    pub fn new(convert: Arc<TokioSemaphore>, upload: Arc<TokioSemaphore>) -> Self {
-        Self { convert, upload }
+    pub fn new(
+        convert: Arc<TokioSemaphore>,
+        upload: Arc<TokioSemaphore>,
+        migrate: Arc<TokioSemaphore>,
+    ) -> Self {
+        Self {
+            convert,
+            upload,
+            migrate,
+        }
     }
 
     pub fn for_kind(&self, kind: JobKind) -> Arc<TokioSemaphore> {
         match kind {
             UPLOAD_KIND => self.upload.clone(),
+            MIGRATE_KIND => self.migrate.clone(),
             _ => self.convert.clone(),
         }
     }
@@ -98,10 +111,10 @@ pub trait Job: Clone + Sized + Send + Sync + 'static {
 
             let needed_permits = self.need_permit();
             let semaphore = semaphores.for_kind(kind);
-            let pool_limit = if kind == UPLOAD_KIND {
-                1
-            } else {
-                state.permits
+            let pool_limit = match kind {
+                UPLOAD_KIND => 1,
+                MIGRATE_KIND => state.migrate_permits,
+                _ => state.permits,
             };
             let _permit = if needed_permits > 0 {
                 let acquire = u32::try_from(needed_permits.min(pool_limit))
@@ -191,9 +204,10 @@ impl Action {
                 }
             }
             Action::Webhook { message } => {
-                info!(job_id, kind, message, "Calling webhook(unimplemented)");
-                // TODO: call webhook
-                // state.call_webhook(job_id, kind, "failed").await;
+                info!(
+                    job_id,
+                    kind, message, "Skipping failure webhook by configuration"
+                );
             }
         }
     }
@@ -241,7 +255,7 @@ mod tests {
         .await
         .expect("initialize storage manager");
 
-        let state = AppState::new(1, &workspace_path, storage_manager, None, Vec::new())
+        let state = AppState::new(1, 1, &workspace_path, storage_manager, None, Vec::new())
             .await
             .expect("create app state");
 

--- a/crates/core/src/job/raw.rs
+++ b/crates/core/src/job/raw.rs
@@ -1,6 +1,7 @@
 use crate::app_state::AppState;
-use crate::job::{FailureJob, Job, JobKind};
+use crate::job::{CONVERT_KIND, FailureJob, Job, JobKind, MIGRATE_KIND, MigrateJob, UPLOAD_KIND};
 use crate::{ConvertJob, UploadJob};
+use anyhow::{Result, anyhow};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use std::cmp::Ordering;
@@ -37,23 +38,57 @@ impl SerdeAbleRawJob {
         self.raw.clone()
     }
 
-    pub fn to_json(&self) -> JsonValue {
+    pub fn payload_json(&self) -> JsonValue {
         (self.serializer)(&self.raw)
     }
 
-    pub fn from_json(value: JsonValue) -> Result<Self, serde_json::Error> {
-        #[derive(serde::Deserialize)]
-        #[serde(untagged)]
-        enum DeserAbleJob {
-            Convert(ConvertJob),
-            Upload(UploadJob),
-        }
-
-        let job = serde_json::from_value::<DeserAbleJob>(value)?;
-        Ok(match job {
-            DeserAbleJob::Convert(job) => SerdeAbleRawJob::new(job),
-            DeserAbleJob::Upload(job) => SerdeAbleRawJob::new(job),
+    pub fn to_json(&self) -> JsonValue {
+        serde_json::json!({
+            "kind": self.kind(),
+            "job": self.payload_json(),
         })
+    }
+
+    pub fn from_json(value: JsonValue) -> Result<Self> {
+        match value.get("kind").and_then(JsonValue::as_str) {
+            Some(kind) => {
+                let payload = value
+                    .get("job")
+                    .cloned()
+                    .ok_or_else(|| anyhow!("stored job payload missing `job` field"))?;
+                Self::from_kind_and_payload(kind, payload)
+            }
+            None => Self::from_legacy_json(value),
+        }
+    }
+
+    fn from_kind_and_payload(kind: &str, payload: JsonValue) -> Result<Self> {
+        match kind {
+            CONVERT_KIND => Ok(SerdeAbleRawJob::new(serde_json::from_value::<ConvertJob>(
+                payload,
+            )?)),
+            UPLOAD_KIND => Ok(SerdeAbleRawJob::new(serde_json::from_value::<UploadJob>(
+                payload,
+            )?)),
+            MIGRATE_KIND => Ok(SerdeAbleRawJob::new(serde_json::from_value::<MigrateJob>(
+                payload,
+            )?)),
+            _ => Err(anyhow!("unsupported job kind `{kind}`")),
+        }
+    }
+
+    fn from_legacy_json(value: JsonValue) -> Result<Self> {
+        // Legacy persisted jobs were stored as raw payloads without an explicit kind tag.
+        // Only convert/upload used that format, so a `crf` field is enough to disambiguate.
+        if value.get("crf").is_some() {
+            Ok(SerdeAbleRawJob::new(serde_json::from_value::<ConvertJob>(
+                value,
+            )?))
+        } else {
+            Ok(SerdeAbleRawJob::new(serde_json::from_value::<UploadJob>(
+                value,
+            )?))
+        }
     }
 }
 
@@ -242,4 +277,40 @@ struct VTable {
 
     clone: fn(*const ()) -> RawJob,
     drop: unsafe fn(*mut ()),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::job::convert::Scales;
+
+    #[test]
+    fn tagged_migrate_jobs_round_trip() {
+        let job = MigrateJob::new(
+            "video123".to_string(),
+            "src".to_string(),
+            "dst".to_string(),
+            vec![480],
+        );
+        let raw = SerdeAbleRawJob::new(job);
+        let json = raw.to_json();
+
+        assert_eq!(json["kind"], MIGRATE_KIND);
+        assert_eq!(json["job"]["src_bucket"], "src");
+        assert_eq!(json["job"]["dst_bucket"], "dst");
+
+        let parsed = SerdeAbleRawJob::from_json(json).expect("parse tagged migrate job");
+        assert_eq!(parsed.kind(), MIGRATE_KIND);
+        assert_eq!(parsed.id(), "video123");
+    }
+
+    #[test]
+    fn legacy_convert_jobs_still_load() {
+        let job = ConvertJob::new("video123".to_string(), 23, Scales::new());
+        let payload = serde_json::to_value(job).expect("serialize convert payload");
+
+        let parsed = SerdeAbleRawJob::from_json(payload).expect("parse legacy convert job");
+        assert_eq!(parsed.kind(), CONVERT_KIND);
+        assert_eq!(parsed.id(), "video123");
+    }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -26,7 +26,7 @@ pub use api::{
 };
 pub use app_state::AppState;
 pub use config::Config;
-pub use job::{ConvertJob, Job, JobResult, UploadJob};
+pub use job::{ConvertJob, Job, JobResult, MigrateJob, UploadJob};
 pub use opendal::{StorageBackend, StorageConfig, StorageManager};
 pub use stream_map::StreamMap;
 
@@ -35,6 +35,7 @@ pub async fn run(config: Config) {
     let listen_on_port = config.listen_on_port;
     let internal_port = config.internal_port;
     let permits = config.permits;
+    let migrate_permits = config.migrate_permits;
     let workspace = config.workspace.clone();
     let webhook_url = config.webhook_url.clone();
     let claim_keys = config.claim_keys.clone();
@@ -79,6 +80,7 @@ pub async fn run(config: Config) {
         .expect("Failed to initialize storage manager");
     let state = AppState::new(
         permits,
+        migrate_permits,
         &workspace_path,
         storage_manager,
         webhook_url,

--- a/crates/core/tests/auth_integration_test.rs
+++ b/crates/core/tests/auth_integration_test.rs
@@ -18,6 +18,7 @@ async fn test_server_starts_successfully() {
     let body: serde_json::Value = response.json().await.unwrap();
     assert!(body.get("pending_convert_jobs").is_some());
     assert!(body.get("pending_upload_jobs").is_some());
+    assert!(body.get("pending_migrate_jobs").is_some());
     assert!(body.get("total_pending_jobs").is_some());
 }
 

--- a/crates/core/tests/s3_optional_integration_test.rs
+++ b/crates/core/tests/s3_optional_integration_test.rs
@@ -2,9 +2,9 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use opendal::Operator;
-use video_storage_core::api::routes::{MigrateRequest, MigrateResponse};
+use video_storage_core::api::routes::{MigrateAcceptedResponse, MigrateRequest};
 use video_storage_core::{StorageBackend, StorageConfig, StorageManager};
-use video_storage_test_server::TestServer;
+use video_storage_test_server::{MockWebhook, TestServer};
 
 fn required_env(name: &str) -> String {
     std::env::var(name).unwrap_or_else(|_| {
@@ -57,6 +57,7 @@ async fn test_s3_serve_and_migrate_between_buckets_minio() {
     let src_bucket = required_env("VS_TEST_S3_SRC_BUCKET");
     let dst_bucket = required_env("VS_TEST_S3_DST_BUCKET");
 
+    let webhook = MockWebhook::start().await;
     let server = TestServer::start_with_config(|cfg| {
         cfg.storage_backend = "s3".into();
         cfg.s3_endpoint = Some(endpoint.clone());
@@ -64,6 +65,7 @@ async fn test_s3_serve_and_migrate_between_buckets_minio() {
         cfg.s3_bucket = Some(src_bucket.clone());
         cfg.s3_access_key_id = Some(access_key_id.clone());
         cfg.s3_secret_access_key = Some(secret_access_key.clone());
+        cfg.webhook_url = Some(webhook.url());
     })
     .await;
 
@@ -168,7 +170,6 @@ async fn test_s3_serve_and_migrate_between_buckets_minio() {
         src_bucket: src_bucket.clone(),
         dst_bucket: dst_bucket.clone(),
         widths: Some(vec![480]),
-        dry_run: false,
     };
     let response = client
         .post(format!("{}/migrate", server.int_url()))
@@ -176,14 +177,21 @@ async fn test_s3_serve_and_migrate_between_buckets_minio() {
         .send()
         .await
         .unwrap();
-    assert_eq!(response.status(), 200);
-    let migrate: MigrateResponse = response.json().await.unwrap();
+    assert_eq!(response.status(), 202);
+    let migrate: MigrateAcceptedResponse = response.json().await.unwrap();
     assert_eq!(migrate.job_id, job_id);
-    assert_eq!(migrate.src_bucket, src_bucket);
-    assert_eq!(migrate.dst_bucket, dst_bucket);
-    assert!(!migrate.dry_run);
-    assert_eq!(migrate.objects_total, 4);
-    assert_eq!(migrate.objects_copied, 4);
+    assert!(migrate.message.contains("background"));
+
+    let webhook_received = webhook.wait_for_calls(1, 120).await;
+    assert!(
+        webhook_received,
+        "Migrate webhook was not called within timeout"
+    );
+    let calls = webhook.get_calls().await;
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0]["job_id"], job_id);
+    assert_eq!(calls[0]["job_type"], "migrate");
+    assert_eq!(calls[0]["status"], "completed");
 
     // Verify objects exist in dst bucket and can be served.
     assert_eq!(

--- a/docs/api-zh.md
+++ b/docs/api-zh.md
@@ -180,8 +180,9 @@ curl -g -X POST "http://localhost:32146/upload?id=video2&crf=38&codecs[0]=h265" 
 ```json
 {
   "pending_convert_jobs": 5,      // 待处理的转换任务数
+  "pending_migrate_jobs": 1,      // 待处理的迁移任务数
   "pending_upload_jobs": 2,       // 待处理的上传任务数
-  "total_pending_jobs": 7         // 总待处理任务数
+  "total_pending_jobs": 8         // 总待处理任务数
 }
 ```
 
@@ -210,7 +211,6 @@ curl http://localhost:32146/waitlist
 | src_bucket | string | 是 | 源桶 |
 | dst_bucket | string | 是 | 目标桶 |
 | widths | Vec<u16> | 否 | 需要迁移的清晰度宽度列表；不传则使用服务内置默认分辨率列表 |
-| dry_run | bool | 否 | 是否只统计不执行复制；默认 false |
 
 Bucket 限制：
 - 不能为空
@@ -219,18 +219,17 @@ Bucket 限制：
 
 #### 响应格式
 
-成功响应 (200 OK):
+成功响应 (202 Accepted):
 ```json
 {
   "job_id": "video123",
-  "src_bucket": "old-bucket",
-  "dst_bucket": "new-bucket",
-  "dry_run": false,
-  "objects_total": 4,
-  "objects_copied": 4,
-  "bytes_copied": 12345
+  "message": "Processing in background"
 }
 ```
+
+说明：
+- `/migrate` 现在是异步任务接口，成功入队后立即返回。
+- 迁移成功时会发送通用 webhook；失败仅记录日志，不回调上游。
 
 错误响应：
 
@@ -253,8 +252,7 @@ curl -X POST http://localhost:32146/migrate \
     "job_id": "video123",
     "src_bucket": "old-bucket",
     "dst_bucket": "new-bucket",
-    "widths": [480],
-    "dry_run": false
+    "widths": [480]
   }'
 ```
 
@@ -500,7 +498,7 @@ s3_secret_access_key = "minioadmin"
 当使用 `storage_backend = "s3"` 时，bucket 由上层服务在请求/任务参数中指定：
 - 上传/转码：`POST /upload?...&dst_bucket=<bucket>`
 - 播放读取：`GET /videos/<bucket>/<key>`
-- 迁移对象：`POST /migrate {src_bucket, dst_bucket, job_id, ...}`
+- 迁移对象：`POST /migrate {src_bucket, dst_bucket, job_id, ...}`，异步返回 `202`
 - 注意：`dst_bucket` 不允许为纯数字（例如 `123`），以避免与清晰度路径（如 `720/...`）产生歧义。
 
 ### 认证密钥配置


### PR DESCRIPTION
## Summary

Move `/migrate` from synchronous request handling to the existing background job system so large bucket migrations no longer time out in the request path.

## Changes

- add `MigrateJob` and integrate it into the job pipeline
- change `/migrate` to validate + enqueue and return `202 Accepted`
- remove `dry_run` from the migrate API
- add isolated migrate concurrency via `migrate_permits`
- add `pending_migrate_jobs` to `/waitlist`
- persist migrate jobs in `pending-jobs.json`
- upgrade pending job serialization to a tagged format
- keep backward compatibility for legacy persisted jobs
- keep migrate failure handling as logs only, no failure webhook
- add migrate discovery/progress logs for easier debugging
- update docs and example config for the new async migrate flow

## Behavior Notes

- duplicate migrate requests for the same in-progress `job_id` are rejected, consistent with the existing upload behavior
- source objects are still not deleted after migration
- success still emits the standard webhook payload

## Testing

Ran:

- `cargo fmt --all`
- `cargo clippy -p video-storage-core -p video-storage-test-server --all-targets -- -D warnings`
- `cargo test -p video-storage-core --lib`
- `cargo test -p video-storage-core --tests --no-run`

## Compatibility

- `/migrate` response changed from synchronous result payload to async accepted response
- legacy persisted job payloads remain readable
